### PR TITLE
Added package path in tsconfig.json

### DIFF
--- a/frontend_addon/{{ cookiecutter.__folder_name }}/packages/{{ cookiecutter.frontend_addon_name }}/tsconfig.json
+++ b/frontend_addon/{{ cookiecutter.__folder_name }}/packages/{{ cookiecutter.frontend_addon_name }}/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es2022", "dom", "dom.iterable"],
     "jsx": "react-jsx",
     "paths": {
-      "@plone/volto/*": ["../../core/packages/volto/src/*"]
+      "@plone/volto/*": ["../../core/packages/volto/src/*"],
+      "{{ cookiecutter.__npm_package_name }}/*": ["./src/*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
Added paths configuration for the package in the tsconfig so typescript can find imports correctly, for example:

```typescript
import type { MyBlockProps } from '@redturtle/volto-blocks/components/blocks/MyBlock/schema';
````