### PR TITLE
Fix tox -e lint when run inside the backend folder

### DIFF
--- a/backend_addon/{{ cookiecutter.__folder_name }}/tox.ini
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/tox.ini
@@ -59,7 +59,8 @@ skip_install = true
 deps =
     pre-commit
 commands =
-    pre-commit run -a
+    # Run pre-commit without chdir to the root of the git repository
+    python -c "from pre_commit import main; main._adjust_args_and_chdir = lambda args: None; raise SystemExit(main.main())" run -a
 
 [testenv:dependencies]
 description = check if the package defines all its dependencies


### PR DESCRIPTION
The problem is not really pre-commit itself, but the interaction between pre-commit doing a chdir to the root of the git repository (that's what this avoids) and particular pre-commit plugins which assume the current directory has pyproject.toml