### PR TITLE
Add plonecli/bobtemplates.plone compatible markers and configuration

### DIFF
--- a/backend_addon/{{ cookiecutter.__folder_name }}/.mrbob.ini
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/.mrbob.ini
@@ -1,0 +1,4 @@
+[variables]
+package.dottedname = {{ cookiecutter.python_package_name }}
+package.browserlayer = IBrowserLayer
+

--- a/backend_addon/{{ cookiecutter.__folder_name }}/Makefile
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/Makefile
@@ -115,3 +115,7 @@ test: $(BIN_FOLDER)/tox ## run tests
 .PHONY: test-coverage
 test-coverage: $(BIN_FOLDER)/tox ## run tests with coverage
 	$(BIN_FOLDER)/tox -e coverage
+
+## Add bobtemplates features (check bobtemplates.plone's documentation to get the list of available features)
+add: $(BIN_FOLDER)/pipx
+	$(BIN_FOLDER)/pipx run plonecli add -b .mrbob.ini $(filter-out $@,$(MAKECMDGOALS))

--- a/backend_addon/{{ cookiecutter.__folder_name }}/README.md
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/README.md
@@ -24,7 +24,7 @@ make create_site
 
 This package provides plonecli/bobtemplates.plone compatible entrypoints to add all kind of subtemplates provided by them.
 
-To use them, you need to use bobtemplates.plone version > X.X.X and run your command as follows:
+To use them, you need to use `bobtemplates.plone` version X.X.X or later, and run the following command.
 
 ```shell
 plonecli add -b .mrbob.ini content_type

--- a/backend_addon/{{ cookiecutter.__folder_name }}/README.md
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/README.md
@@ -24,7 +24,7 @@ make create_site
 This package provides markers as strings (`<!-- extra stuff goes here -->`) that are compatible with [`plonecli`](https://github.com/plone/plonecli) and [`bobtemplates.plone`](https://github.com/plone/bobtemplates.plone).
 These markers act as hooks to add all kinds of subtemplates, including behaviors, control panels, upgrade steps, or other subtemplates from `plonecli`.
 
-To use them, you need to use `bobtemplates.plone` version X.X.X or later, and run the following command.
+To use them, you need to use `bobtemplates.plone` version 6.3.4 or later, and run the following command.
 
 ```shell
 plonecli add -b .mrbob.ini content_type

--- a/backend_addon/{{ cookiecutter.__folder_name }}/README.md
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/README.md
@@ -13,6 +13,7 @@ Install {{ cookiecutter.python_package_name }} with `pip`:
 ```shell
 pip install {{ cookiecutter.python_package_name }}
 ```
+
 And to create the Plone site:
 
 ```shell
@@ -24,31 +25,28 @@ make create_site
 This package provides markers as strings (`<!-- extra stuff goes here -->`) that are compatible with [`plonecli`](https://github.com/plone/plonecli) and [`bobtemplates.plone`](https://github.com/plone/bobtemplates.plone).
 These markers act as hooks to add all kinds of subtemplates, including behaviors, control panels, upgrade steps, or other subtemplates from `plonecli`.
 
-To use them, you need to use `bobtemplates.plone` version 6.3.4 or later, and run the following command.
+To run `plonecli` with configuration to target this package, run the following command.
 
 ```shell
-plonecli add -b .mrbob.ini content_type
+make add <template_name>
 ```
 
-The command passes the `.mrbob.ini` configuration file to `plonecli` to set some configuration variables which are needed to properly run the subtemplates.
-
-For example, you can add a behavior to your package with the following command.
+For example, you can add a content type to your package with the following command.
 
 ```shell
-plonecli add -b .mrbob.ini behavior
+make add content_type
 ```
 
-You can add a control panel with the following command.
+You can add a behavior with the following command.
 
 ```shell
-plonecli add -b .mrbob.ini controlpanel
+make add behavior
 ```
 
 ```{seealso}
 You can check the list of available subtemplates in the [`bobtemplates.plone` `README.md` file](https://github.com/plone/bobtemplates.plone/?tab=readme-ov-file#provided-subtemplates).
 See also the documentation of [Mockup and Patternslib](https://6.docs.plone.org/classic-ui/mockup.html) for how to build the UI toolkit for Classic UI.
 ```
-
 
 ## Contribute
 

--- a/backend_addon/{{ cookiecutter.__folder_name }}/README.md
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/README.md
@@ -32,21 +32,22 @@ plonecli add -b .mrbob.ini content_type
 
 The command passes the `.mrbob.ini` configuration file to `plonecli` to set some configuration variables which are needed to properly run the subtemplates.
 
-
-For instance, you could add a behavior to your package running this command:
+For example, you can add a behavior to your package with the following command.
 
 ```shell
 plonecli add -b .mrbob.ini behavior
 ```
 
-Or a controlpanel running this other command:
+You can add a control panel with the following command.
 
 ```shell
 plonecli add -b .mrbob.ini controlpanel
 ```
 
-You can check the list of available subtemplates in the [bobtemplates.plone README file](https://github.com/plone/bobtemplates.plone/?tab=readme-ov-file#provided-subtemplates)
-
+```{seealso}
+You can check the list of available subtemplates in the [`bobtemplates.plone` `README.md` file](https://github.com/plone/bobtemplates.plone/?tab=readme-ov-file#provided-subtemplates).
+See also the documentation of [Mockup and Patternslib](https://6.docs.plone.org/classic-ui/mockup.html) for how to build the UI toolkit for Classic UI.
+```
 
 
 ## Contribute

--- a/backend_addon/{{ cookiecutter.__folder_name }}/README.md
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/README.md
@@ -20,7 +20,7 @@ make create_site
 
 ```
 
-## Add features using plonecli/bobtemplates.plone
+## Add features using `plonecli` or `bobtemplates.plone`
 
 This package provides plonecli/bobtemplates.plone compatible entrypoints to add all kind of subtemplates provided by them.
 

--- a/backend_addon/{{ cookiecutter.__folder_name }}/README.md
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/README.md
@@ -32,6 +32,22 @@ plonecli add -b .mrbob.ini content_type
 The command passes the `.mrbob.ini` configuration file to `plonecli` to set some configuration variables which are needed to properly run the subtemplates.
 
 
+For instance, you could add a behavior to your package running this command:
+
+```shell
+plonecli add -b .mrbob.ini behavior
+```
+
+Or a controlpanel running this other command:
+
+```shell
+plonecli add -b .mrbob.ini controlpanel
+```
+
+You can check the list of available subtemplates in the [bobtemplates.plone README file](https://github.com/plone/bobtemplates.plone/?tab=readme-ov-file#provided-subtemplates)
+
+
+
 ## Contribute
 
 - [Issue Tracker](https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.python_package_name }}/issues)

--- a/backend_addon/{{ cookiecutter.__folder_name }}/README.md
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/README.md
@@ -21,7 +21,8 @@ make create_site
 
 ## Add features using `plonecli` or `bobtemplates.plone`
 
-This package provides plonecli/bobtemplates.plone compatible entrypoints to add all kind of subtemplates provided by them.
+This package provides markers as strings (`<!-- extra stuff goes here -->`) that are compatible with [`plonecli`](https://github.com/plone/plonecli) and [`bobtemplates.plone`](https://github.com/plone/bobtemplates.plone).
+These markers act as hooks to add all kinds of subtemplates, including behaviors, control panels, upgrade steps, or other subtemplates from `plonecli`.
 
 To use them, you need to use `bobtemplates.plone` version X.X.X or later, and run the following command.
 

--- a/backend_addon/{{ cookiecutter.__folder_name }}/README.md
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/README.md
@@ -30,7 +30,7 @@ To use them, you need to use bobtemplates.plone version > X.X.X and run your com
 plonecli add -b .mrbob.ini content_type
 ```
 
-This way we are passing the `.mrbob.ini` configuration file to plonecli to set some configuration variables needed to properly run the subtemplates.
+The command passes the `.mrbob.ini` configuration file to `plonecli` to set some configuration variables which are needed to properly run the subtemplates.
 
 
 ## Contribute

--- a/backend_addon/{{ cookiecutter.__folder_name }}/README.md
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/README.md
@@ -17,7 +17,21 @@ And to create the Plone site:
 
 ```shell
 make create_site
+
 ```
+
+## Add features using plonecli/bobtemplates.plone
+
+This package provides plonecli/bobtemplates.plone compatible entrypoints to add all kind of subtemplates provided by them.
+
+To use them, you need to use bobtemplates.plone version > X.X.X and run your command as follows:
+
+```shell
+plonecli add -b .mrbob.ini content_type
+```
+
+This way we are passing the `.mrbob.ini` configuration file to plonecli to set some configuration variables needed to properly run the subtemplates.
+
 
 ## Contribute
 

--- a/backend_addon/{{ cookiecutter.__folder_name }}/README.md
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/README.md
@@ -17,7 +17,6 @@ And to create the Plone site:
 
 ```shell
 make create_site
-
 ```
 
 ## Add features using `plonecli` or `bobtemplates.plone`

--- a/backend_addon/{{ cookiecutter.__folder_name }}/bobtemplate.cfg
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/bobtemplate.cfg
@@ -1,0 +1,5 @@
+[main]
+version = 6.0.13
+template = plone_addon
+git_init = True
+python = python3

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/configure.zcml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/configure.zcml
@@ -21,4 +21,6 @@
   {%- endif %}
   <include package=".vocabularies" />
 
+  <!-- -*- extra stuff goes here -*- -->
+
 </configure>

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/configure.zcml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/configure.zcml
@@ -11,8 +11,10 @@
       file="permissions.zcml"
       />
 
+
   <include file="dependencies.zcml" />
   <include file="profiles.zcml" />
+  <include file="permissions.zcml"/>
 
   <include package=".controlpanel" />
   <include package=".indexers" />

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/controlpanel/configure.zcml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/controlpanel/configure.zcml
@@ -5,4 +5,6 @@
     i18n_domain="{{ cookiecutter.python_package_name }}"
     >
 
+  <!-- -*- extra stuff goes here -*- -->
+
 </configure>

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/indexers/configure.zcml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/indexers/configure.zcml
@@ -2,4 +2,6 @@
 
   <!-- Indexers/Metadata -->
 
+  <!-- -*- extra stuff goes here -*- -->
+
 </configure>

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/permissions.zcml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/permissions.zcml
@@ -1,0 +1,10 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="{{ cookiecutter.python_package_name }}"
+    >
+
+  <!-- -*- extra stuff goes here -*- -->
+
+
+</configure>

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/permissions.zcml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/permissions.zcml
@@ -6,5 +6,4 @@
 
   <!-- -*- extra stuff goes here -*- -->
 
-
 </configure>

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/profiles/default/controlpanel.xml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/profiles/default/controlpanel.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <object name="portal_controlpanel">
 
+<!-- -*- extra stuff goes here -*- -->
+
+
 </object>

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/profiles/default/controlpanel.xml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/profiles/default/controlpanel.xml
@@ -3,5 +3,4 @@
 
 <!-- -*- extra stuff goes here -*- -->
 
-
 </object>

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/profiles/default/registry/main.xml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/profiles/default/registry/main.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<registry
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    i18n:domain="{{ cookiecutter.python_package_name }}">
+
+<!-- -*- extra stuff goes here -*- -->
+
+</registry>

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/profiles/default/rolemap.xml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/profiles/default/rolemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rolemap>
   <permissions>
-
+    <!-- -*- extra stuff goes here -*- -->
   </permissions>
 </rolemap>

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/upgrades/configure.zcml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/upgrades/configure.zcml
@@ -16,4 +16,6 @@
   </genericsetup:upgradeSteps>
   -->
 
+  <!-- -*- extra stuff goes here -*- -->
+
 </configure>

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/vocabularies/configure.zcml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/vocabularies/configure.zcml
@@ -1,3 +1,6 @@
 <configure xmlns="http://namespaces.zope.org/zope">
 
+    <!-- -*- extra stuff goes here -*- -->
+
+
 </configure>

--- a/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/vocabularies/configure.zcml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/src/packagename/vocabularies/configure.zcml
@@ -2,5 +2,4 @@
 
     <!-- -*- extra stuff goes here -*- -->
 
-
 </configure>

--- a/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -143,7 +143,7 @@ acceptance-backend-start: ## Start backend acceptance server
 acceptance-image-build:  ## Build Docker Images
 	@DOCKER_BUILDKIT=1 docker build . -t $(IMAGE_NAME_PREFIX)-backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
 
-.PHONY: add
-add: ## Add bobtemplates features (check bobtemplates.plone's documentation to get the list of available features)
+## Add bobtemplates features (check bobtemplates.plone's documentation to get the list of available features)
+add: $(BIN_FOLDER)/pipx
 	$(BIN_FOLDER)/pipx run plonecli add -b .mrbob.ini $(filter-out $@,$(MAKECMDGOALS))
 

--- a/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -145,5 +145,5 @@ acceptance-image-build:  ## Build Docker Images
 
 .PHONY: add
 add: ## Add bobtemplates features (check bobtemplates.plone's documentation to get the list of available features)
-	$(BIN_FOLDER)/uv run plonecli add -b .mrbob.ini $(filter-out $@,$(MAKECMDGOALS))
+	$(BIN_FOLDER)/pipx run plonecli add -b .mrbob.ini $(filter-out $@,$(MAKECMDGOALS))
 

--- a/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -142,3 +142,8 @@ acceptance-backend-start: ## Start backend acceptance server
 .PHONY: acceptance-image-build
 acceptance-image-build:  ## Build Docker Images
 	@DOCKER_BUILDKIT=1 docker build . -t $(IMAGE_NAME_PREFIX)-backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
+
+.PHONY: add
+add: ## Add bobtemplates features (check bobtemplates.plone's documentation to get the list of available features)
+	$(BIN_FOLDER)/uv run plonecli add -b .mrbob.ini $(filter-out $@,$(MAKECMDGOALS))
+


### PR DESCRIPTION
Adding these markers, one can use `plonecli` to add features to the backend addon.

This needs https://github.com/plone/bobtemplates.plone/pull/568 to correctly work. 

And also some documentation that I will be adding in the backend package's README file, because it needs to run `plonecli` with the custom configuration file provided here.

I think that plonecli/bobtemplates.plone is mature enough and saves a lot of time when adding features to backend, and it will be definelty useful in a project/add-on generator like this.