### PR TITLE
do not hard-code the created username to plone, use the one set in the .env file

### DIFF
--- a/project/{{ cookiecutter.__folder_name }}/devops/inventory/group_vars/all/users.yml
+++ b/project/{{ cookiecutter.__folder_name }}/devops/inventory/group_vars/all/users.yml
@@ -1,6 +1,6 @@
 ---
 users:
   default:
-    name: plone
+    name: "{{ lookup('ansible.builtin.env', 'DEPLOY_USER') }}"
     group: sudo
     additional_keys: []


### PR DESCRIPTION
We are hardcoding the username of the user created during the server-setup to `plone`. But we are also setting the username to be used to do the deployments in the `.env` file. 

With this small change, we reuse the username to be created from the .env file (variable DEPLOY_USER)