### PR TITLE
[DRAFT] use local env_vars and not remove server's one

### DIFF
--- a/project/{{ cookiecutter.__folder_name }}/devops/inventory/group_vars/all/projects.yml
+++ b/project/{{ cookiecutter.__folder_name }}/devops/inventory/group_vars/all/projects.yml
@@ -1,7 +1,7 @@
 ---
 project_folders:
   # Path to store {{ cookiecutter.hostname }} postgres data
-    path: "{{ lookup('ansible.builtin.env', 'DEPLOY_FOLDER', default='/srv/plone/data') }}"
+  - path: "{{ lookup('env', 'DEPLOY_FOLDER', default='/srv/plone/data') }}"
     owner: 999
     group: 999
     mode: "0750"

--- a/project/{{ cookiecutter.__folder_name }}/devops/inventory/group_vars/all/users.yml
+++ b/project/{{ cookiecutter.__folder_name }}/devops/inventory/group_vars/all/users.yml
@@ -1,6 +1,6 @@
 ---
 users:
   default:
-    name: "{{ lookup('ansible.builtin.env', 'DEPLOY_USER', default='plone') }}"
+    name: "{{ lookup('env', 'DEPLOY_USER', default='plone') }}"
     group: sudo
     additional_keys: []


### PR DESCRIPTION
With my previouse changes we were using env vars present in the remote server instead of the ones present in the local .env file.

Moreover I deleted a `- ` in the `project_folders` variable which is important.

