### PR TITLE
Better release for addons - Use the `prerelease` script from core

### DIFF
--- a/frontend_addon/{{ cookiecutter.__folder_name }}/Makefile
+++ b/frontend_addon/{{ cookiecutter.__folder_name }}/Makefile
@@ -50,10 +50,10 @@ start: ## Starts Volto, allowing reloading of the add-on during development
 build: ## Build a production bundle for distribution of the project with the add-on
 	pnpm build
 
-core/packages/registry/dist: core/packages/registry/src
+core/packages/registry/dist: $(shell find core/packages/registry/src -type f)
 	pnpm --filter @plone/registry build
 
-core/packages/components/dist: core/packages/components/src
+core/packages/components/dist: $(shell find core/packages/components/src -type f)
 	pnpm --filter @plone/components build
 
 .PHONY: build-deps

--- a/frontend_addon/{{ cookiecutter.__folder_name }}/packages/{{ cookiecutter.frontend_addon_name }}/.release-it.json
+++ b/frontend_addon/{{ cookiecutter.__folder_name }}/packages/{{ cookiecutter.frontend_addon_name }}/.release-it.json
@@ -1,4 +1,7 @@
 {
+  "plugins": {
+    "../../core/packages/scripts/prepublish.js": {}
+  },
   "hooks": {
     "after:bump": [
       "pipx run towncrier build --draft --yes --version ${version} > .changelog.draft",
@@ -8,6 +11,9 @@
       "git add ../../CHANGELOG.md ../../package.json"
     ],
     "after:release": "rm .changelog.draft README.md"
+  },
+  "npm": {
+    "publish": false
   },
   "git": {
     "changelog": "pipx run towncrier build --draft --yes --version 0.0.0",

--- a/sub/frontend_project/{{ cookiecutter.__folder_name }}/_project_files/Makefile
+++ b/sub/frontend_project/{{ cookiecutter.__folder_name }}/_project_files/Makefile
@@ -44,10 +44,10 @@ start: ## Starts Volto, allowing reloading of the add-on during development
 build: ## Build a production bundle for distribution of the project with the add-on
 	pnpm build
 
-core/packages/registry/dist: core/packages/registry/src
+core/packages/registry/dist: $(shell find core/packages/registry/src -type f)
 	pnpm --filter @plone/registry build
 
-core/packages/components/dist: core/packages/components/src
+core/packages/components/dist: $(shell find core/packages/components/src -type f)
 	pnpm --filter @plone/components build
 
 .PHONY: build-deps

--- a/sub/project_settings/{{ cookiecutter.__folder_name }}/frontend/Makefile
+++ b/sub/project_settings/{{ cookiecutter.__folder_name }}/frontend/Makefile
@@ -48,10 +48,10 @@ start: ## Starts Volto, allowing reloading of the add-on during development
 build: ## Build a production bundle for distribution of the project with the add-on
 	pnpm build
 
-core/packages/registry/dist: core/packages/registry/src
+core/packages/registry/dist: $(shell find core/packages/registry/src -type f)
 	pnpm --filter @plone/registry build
 
-core/packages/components/dist: core/packages/components/src
+core/packages/components/dist: $(shell find core/packages/components/src -type f)
 	pnpm --filter @plone/components build
 
 .PHONY: build-deps


### PR DESCRIPTION
This resolves all the `workspace:*` entries in the add-on `package.json` before releasing.