### PR TITLE
Improve the copy of the deps from the project to the boilerplate

### DIFF
--- a/sub/project_settings/{{ cookiecutter.__folder_name }}/frontend/Dockerfile
+++ b/sub/project_settings/{{ cookiecutter.__folder_name }}/frontend/Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=node package.json /app/package.json.temp
 
 RUN --mount=type=cache,id=pnpm,target=/app/.pnpm-store,uid=1000 <<EOT
     set -e
-    python3 -c "import json; data = json.load(open('package.json.temp')); deps = data['dependencies']; data['dependencies'].update(deps); json.dump(data, open('package.json', 'w'), indent=2)"
+    python3 -c "import json; orig_data = json.load(open('package.json.temp')); orig_deps = orig_data['dependencies']; data = json.load(open('package.json')); data['dependencies'].update(orig_deps); json.dump(data, open('package.json', 'w'), indent=2)"
     rm package.json.temp
     pnpm install && pnpm build:deps
     pnpm build


### PR DESCRIPTION
I have doubts if the install command does not have to be a plain `make install`.