### PR TITLE
change clean command not to delete data and add a reset-data command to remove data

### DIFF
--- a/backend_addon/{{ cookiecutter.__folder_name }}/Makefile
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/Makefile
@@ -73,7 +73,12 @@ build: build-dev ## Install Plone
 .PHONY: clean
 clean: ## Clean environment
 	@echo "$(RED)==> Cleaning environment and build$(RESET)"
-	rm -rf $(VENV_FOLDER) pyvenv.cfg .installed.cfg instance .tox .venv .pytest_cache
+	rm -rf $(VENV_FOLDER) pyvenv.cfg .installed.cfg instance/etc .tox .venv .pytest_cache
+
+.PHONY: remove-data
+remove-data: ## Remove all content
+	@echo "$(RED)==> Removing all content$(RESET)"
+	rm -rf $(VENV_FOLDER) instance/var
 
 .PHONY: start
 start: ## Start a Plone instance on localhost:8080

--- a/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -79,7 +79,12 @@ build: build-dev ## Install Plone
 .PHONY: clean
 clean: ## Clean environment
 	@echo "$(RED)==> Cleaning environment and build$(RESET)"
-	rm -rf $(VENV_FOLDER) pyvenv.cfg .installed.cfg instance .tox .venv .pytest_cache
+	rm -rf $(VENV_FOLDER) pyvenv.cfg .installed.cfg instance/etc .tox .venv .pytest_cache
+
+.PHONY: remove-data
+remove-data: ## Remove all content
+	@echo "$(RED)==> Removing all content$(RESET)"
+	rm -rf $(VENV_FOLDER) instance/var
 
 .PHONY: start
 start: ## Start a Plone instance on localhost:8080


### PR DESCRIPTION
This addresses #91 

If merged, from now on we will have 2 different commands in the backend:

- `make clean`: this will remove the virtualenv and instance configuration
- `make remove-data`: this will remove the data stored in `instance/var`