### PR TITLE
Fix lint in project frontend add-on and change to use direct mutations

### DIFF
--- a/sub/project_settings/{{ cookiecutter.__folder_name }}/frontend/packages/{{ cookiecutter.frontend_addon_name }}/src/index.js
+++ b/sub/project_settings/{{ cookiecutter.__folder_name }}/frontend/packages/{{ cookiecutter.frontend_addon_name }}/src/index.js
@@ -1,10 +1,8 @@
 const applyConfig = (config) => {
-  config.settings = {
-    ...config.settings,
-    isMultilingual: false,
-    supportedLanguages: ['{{ cookiecutter.language_code }}'],
-    defaultLanguage: '{{ cookiecutter.language_code }}',
-  };
+  config.settings.isMultilingual = false;
+  config.settings.supportedLanguages = ["{{ cookiecutter.language_code }}"];
+  config.settings.defaultLanguage = "{{ cookiecutter.language_code }}";
+
   return config;
 };
 


### PR DESCRIPTION
@ericof crap, I just realised that either git or cookiecutter does not preserve the trailing CR, so ESlint complains the first time.