### PR TITLE
Update project cookiecutter.json precise organization prompt

### DIFF
--- a/project/cookiecutter.json
+++ b/project/cookiecutter.json
@@ -78,7 +78,7 @@
       "nl": "Nederlands",
       "fi": "Suomi"
     },
-    "github_organization": "GitHub-, GitLab-User (or -Organization) Username from url",
+    "github_organization": "GitHub or GitLab username or organization slug from URL",
     "container_registry": {
       "__prompt__": "Container Registry",
       "github": "GitHub Container Registry",

--- a/project/cookiecutter.json
+++ b/project/cookiecutter.json
@@ -78,7 +78,7 @@
       "nl": "Nederlands",
       "fi": "Suomi"
     },
-    "github_organization": "GitHub or GitLab Username or Organization",
+    "github_organization": "GitHub-, GitLab-User (or -Organization) Username from url",
     "container_registry": {
       "__prompt__": "Container Registry",
       "github": "GitHub Container Registry",


### PR DESCRIPTION
see Ticket #129 and my last comment https://github.com/plone/cookieplone-templates/issues/129#issuecomment-2613955761

Purpose: Clarify that not the speaking name, but the qualified URL part is needed e
here to create the proper url path to the repo.

Further Todo:
Validate the input and warn to avoid whitespace