### PR TITLE
Update .pre-commit-config.yaml | bump check-python-versions – fix checks

### DIFF
--- a/backend_addon/{{ cookiecutter.__folder_name }}/.pre-commit-config.yaml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.21.3"
+    rev: "0.22.0"
     hooks:
     -   id: check-python-versions
         args: ['--only', 'setup.py,pyproject.toml']


### PR DESCRIPTION
misleading Python versions ckeck failure

Fixes ticket: [Update the version of hook "check-python-versions" to support python 3.12 and 3.13 in pre-commit.yaml #166](https://github.com/plone/cookieplone-templates/issues/166)