### PR TITLE
Pin the version of setuptools used for building the package

### DIFF
--- a/backend_addon/{{ cookiecutter.__folder_name }}/pyproject.toml
+++ b/backend_addon/{{ cookiecutter.__folder_name }}/pyproject.toml
@@ -2,7 +2,7 @@
 # https://github.com/plone/meta/tree/main/config/default
 # See the inline comments on how to expand/tweak this configuration file
 [build-system]
-requires = ["setuptools>=68.2"]
+requires = ["setuptools>=68.2,<=75.8.0"]
 
 [tool.towncrier]
 directory = "news/"


### PR DESCRIPTION
Fixes #4130

Setuptools >= 75.8.1 produces a distribution name that can't be loaded by existing releases of Plone. (See also https://github.com/plone/plone.autoinclude/pull/30 which fixes that problem for future Plone releases.)