### PR TITLE
In frontend_addon, ignore the core folder only from the project root

### DIFF
--- a/frontend_addon/{{ cookiecutter.__folder_name }}/.gitignore
+++ b/frontend_addon/{{ cookiecutter.__folder_name }}/.gitignore
@@ -6,7 +6,7 @@ acceptance/cypress/videos/
 acceptance/node_modules
 .storybook-build
 build
-core
+/core
 node_modules
 results
 yarn.lock


### PR DESCRIPTION
This allows other core folders to exist in the project.