### PR TITLE
Allows the use of the API_PATH environment variable in CI

### DIFF
--- a/frontend_addon/{{ cookiecutter.__folder_name }}/Makefile
+++ b/frontend_addon/{{ cookiecutter.__folder_name }}/Makefile
@@ -25,6 +25,7 @@ PRE_COMMIT=pipx run --spec 'pre-commit=={{cookiecutter.__version_pre_commit}}' p
 PLONE_VERSION=6
 DOCKER_IMAGE=plone/server-dev:${PLONE_VERSION}
 DOCKER_IMAGE_ACCEPTANCE=plone/server-acceptance:${PLONE_VERSION}
+API_PATH ?= http://127.0.0.1:55001/plone
 
 ADDON_NAME='{{ cookiecutter.__npm_package_name }}'
 
@@ -126,7 +127,7 @@ acceptance-frontend-dev-start: ## Start acceptance frontend in development mode
 
 .PHONY: acceptance-frontend-prod-start
 acceptance-frontend-prod-start: ## Start acceptance frontend in production mode
-	RAZZLE_API_PATH=http://127.0.0.1:55001/plone pnpm build && pnpm start:prod
+	RAZZLE_API_PATH=$(API_PATH) pnpm build && pnpm start:prod
 
 .PHONY: acceptance-backend-start
 acceptance-backend-start: ## Start backend acceptance server
@@ -142,4 +143,4 @@ acceptance-test: ## Start Cypress in interactive mode
 
 .PHONY: ci-acceptance-test
 ci-acceptance-test: ## Run cypress tests in headless mode for CI
-	pnpm --filter @plone/volto exec cypress run --config-file $(CURRENT_DIR)/cypress.config.js --config specPattern=$(CURRENT_DIR)'/cypress/tests/**/*.{js,jsx,ts,tsx}'
+	pnpm --filter @plone/volto exec cypress run --config-file $(CURRENT_DIR)/cypress.config.js --config specPattern=$(CURRENT_DIR)'/cypress/tests/**/*.{js,jsx,ts,tsx}' --env API_PATH="$(API_PATH)"


### PR DESCRIPTION
In some CI environments, services running inside a container cannot be accessed via the ip `127.0.0.1`. Another host must be used. So we need to "inform" Volto and Cypress of the new Plone host that is running in a container. Volto's Cypress tests allow this with the `API_PATH` environment variable. But Cypress tests do not inherit the OS environment variables. We need to pass the `API_PATH` variable explicitly.

If there is no `API_PATH` environment variable, `http://127.0.0.1:55001/plone` is used.

Closes #177 