### PR TITLE
Acsr patch – update broken link to changelog docs in two CHANGELOG.md files

### DIFF
--- a/news/211.internal
+++ b/news/211.internal
@@ -1,0 +1,1 @@
+Fix broken link to creating a change log entry. @acsr

--- a/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/CHANGELOG.md
+++ b/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- You should *NOT* be adding new change log entries to this file.
      You should create a file in the news directory instead.
      For helpful instructions, please see:
-     https://6.docs.plone.org/volto/developer-guidelines/contributing.html#create-a-pull-request
+     https://6.docs.plone.org/contributing/index.html#contributing-change-log-label
 -->
 
 <!-- towncrier release notes start -->


### PR DESCRIPTION
The link in the current CHANGELOG.md boilerplate pointing to the docs is broken.
I tried to find a current valid link as replacement and provided it as PR.
Please review and replace with a more appropriate link if needed.

broken link:
https://6.docs.plone.org/volto/developer-guidelines/contributing.html#create-a-pull-request

expected possible destination used as replacement:
https://6.docs.plone.org/contributing/index.html#contributing-change-log-label

Suggestion: 
Use a multi step canonical redirection for this link in the future including a revision/version 
e.g. Specific link -> generic link -> current link -> destination

The broken one is present in cookieplone generated projects with this current setup:

'__generator_signature': 'Generated using [Cookieplone (0.9.6)](https://github.com/plone/cookieplone) and [cookieplone-templates (a83957d)](https://github.com/plone/cookieplone-templates/commit/a83957d67a92031ad7f79b150c66349e3e662eef) on 2025-04-15 20:53:09.072397'})})