### PR TITLE
Fix Eslint in IDEs

### DIFF
--- a/news/161.bugfix
+++ b/news/161.bugfix
@@ -1,0 +1,1 @@
+Fix Eslint in IDEs. @wesleybl

--- a/templates/add-ons/frontend/{{ cookiecutter.__folder_name }}/.npmrc
+++ b/templates/add-ons/frontend/{{ cookiecutter.__folder_name }}/.npmrc
@@ -4,3 +4,5 @@ public-hoist-pattern[]=*stylelint*
 public-hoist-pattern[]=*cypress*
 public-hoist-pattern[]=*process*
 public-hoist-pattern[]=*parcel*
+public-hoist-pattern[]=babel-plugin-react-intl
+public-hoist-pattern[]=babel-preset-razzle

--- a/templates/add-ons/frontend/{{ cookiecutter.__folder_name }}/.npmrc
+++ b/templates/add-ons/frontend/{{ cookiecutter.__folder_name }}/.npmrc
@@ -2,7 +2,5 @@ public-hoist-pattern[]=*eslint*
 public-hoist-pattern[]=*prettier*
 public-hoist-pattern[]=*stylelint*
 public-hoist-pattern[]=*cypress*
-public-hoist-pattern[]=*process*
-public-hoist-pattern[]=*parcel*
 public-hoist-pattern[]=babel-plugin-react-intl
 public-hoist-pattern[]=babel-preset-razzle


### PR DESCRIPTION
The generated package includes a `babel.config.js` file that requires the `babel-plugin-react-intl` and `babel-preset-razzle` dependencies. These dependencies are not declared in the package, so they are neither in the root node_modules folder nor in the package's own node_modules folder. When some IDEs run ESLint, they don't recognize that these packages are located in the `.pnpm` subfolder of the root node_modules, which causes a "package not found" error.

So we hoist these packages. This causes them to be placed at the root of the `node_modules` folder in the monorepo root. This way, IDEs’ ESLint can see the packages, and the error no longer occurs.

Closes https://github.com/plone/cookieplone-templates/issues/161