### PR TITLE
Improve isolation of the virtualenv

### DIFF
--- a/news/+isolation.bugfix
+++ b/news/+isolation.bugfix
@@ -1,0 +1,1 @@
+In the backend Makefile, set VIRTUAL_ENV and UV_PYTHON to make sure uv uses the correct virtualenv and Python. @davisagli

--- a/templates/add-ons/backend/{{ cookiecutter.__folder_name }}/Makefile
+++ b/templates/add-ons/backend/{{ cookiecutter.__folder_name }}/Makefile
@@ -32,7 +32,9 @@ PLONE_VERSION := {{ cookiecutter.plone_version }}
 endif
 
 VENV_FOLDER=$(BACKEND_FOLDER)/.venv
+export VIRTUAL_ENV=$(VENV_FOLDER)
 BIN_FOLDER=$(VENV_FOLDER)/bin
+export UV_PYTHON=$(BIN_FOLDER)/python
 
 # Environment variables to be exported
 export PYTHONWARNINGS := ignore

--- a/templates/sub/classic_project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/templates/sub/classic_project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -32,7 +32,9 @@ PLONE_VERSION=$(shell cat $(BACKEND_FOLDER)/version.txt)
 EXAMPLE_CONTENT_FOLDER=${BACKEND_FOLDER}/src/{{ cookiecutter.__package_path }}/setuphandlers/examplecontent
 
 VENV_FOLDER=$(BACKEND_FOLDER)/.venv
+export VIRTUAL_ENV=$(VENV_FOLDER)
 BIN_FOLDER=$(VENV_FOLDER)/bin
+export UV_PYTHON=$(BIN_FOLDER)/python
 
 # Environment variables to be exported
 export PYTHONWARNINGS := ignore

--- a/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -32,7 +32,9 @@ PLONE_VERSION=$(shell cat $(BACKEND_FOLDER)/version.txt)
 EXAMPLE_CONTENT_FOLDER=${BACKEND_FOLDER}/src/{{ cookiecutter.__package_path }}/setuphandlers/examplecontent
 
 VENV_FOLDER=$(BACKEND_FOLDER)/.venv
+export VIRTUAL_ENV=$(VENV_FOLDER)
 BIN_FOLDER=$(VENV_FOLDER)/bin
+export UV_PYTHON=$(BIN_FOLDER)/python
 
 # Environment variables to be exported
 export PYTHONWARNINGS := ignore


### PR DESCRIPTION
Make sure make commands that run uv use the Python in .venv even if a different virtualenv is active.

Fixes #254, hopefully