### PR TITLE
Avoid locking issue when creating site with filestorage (alternative)

### DIFF
--- a/news/257.bugfix
+++ b/news/257.bugfix
@@ -1,0 +1,1 @@
+Avoid locking issue when creating stack site while using filestorage. @davisagli

--- a/templates/projects/classic/{{ cookiecutter.__folder_name }}/Makefile
+++ b/templates/projects/classic/{{ cookiecutter.__folder_name }}/Makefile
@@ -115,16 +115,17 @@ build-images:  ## Build container images
 ###########################################
 # Local Stack
 ###########################################
+.PHONY: stack-create-site
+stack-create-site:  ## Local Stack: Create a new site
+	@echo "Create a new site in the local Docker stack"
+	@echo "(Stack must not be running already.)"
+	PLONE_VERSION=$(PLONE_VERSION) docker compose -f docker-compose.yml run --build backend ./docker-entrypoint.sh create-site
+
 .PHONY: stack-start
 stack-start:  ## Local Stack: Start Services
 	@echo "Start local Docker stack"
 	PLONE_VERSION=$(PLONE_VERSION) docker compose -f docker-compose.yml up -d --build
 	@echo "Now visit: http://{{ cookiecutter.__project_slug }}.localhost"
-
-.PHONY: stack-create-site
-stack-create-site:  ## Local Stack: Create a new site
-	@echo "Create a new site in the local Docker stack"
-	PLONE_VERSION=$(PLONE_VERSION) docker compose -f docker-compose.yml exec backend ./docker-entrypoint.sh create-site
 
 .PHONY: stack-status
 stack-status:  ## Local Stack: Check Status

--- a/templates/projects/classic/{{ cookiecutter.__folder_name }}/README.md
+++ b/templates/projects/classic/{{ cookiecutter.__folder_name }}/README.md
@@ -60,8 +60,8 @@ Deploy a local Docker Compose environment that includes the following.
 Run the following commands in a shell session.
 
 ```shell
-make stack-start
 make stack-create-site
+make stack-start
 ```
 
 And... you're all set! Your Plone site is up and running locally! 🚀

--- a/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/Makefile
+++ b/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/Makefile
@@ -142,16 +142,17 @@ build-images:  ## Build container images
 ###########################################
 # Local Stack
 ###########################################
+.PHONY: stack-create-site
+stack-create-site:  ## Local Stack: Create a new site
+	@echo "Create a new site in the local Docker stack"
+	@echo "(Stack must not be running already.)"
+	VOLTO_VERSION=$(VOLTO_VERSION) PLONE_VERSION=$(PLONE_VERSION) docker compose -f docker-compose.yml run --build backend ./docker-entrypoint.sh create-site
+
 .PHONY: stack-start
 stack-start:  ## Local Stack: Start Services
 	@echo "Start local Docker stack"
 	VOLTO_VERSION=$(VOLTO_VERSION) PLONE_VERSION=$(PLONE_VERSION) docker compose -f docker-compose.yml up -d --build
 	@echo "Now visit: http://{{ cookiecutter.__project_slug }}.localhost"
-
-.PHONY: stack-create-site
-stack-create-site:  ## Local Stack: Create a new site
-	@echo "Create a new site in the local Docker stack"
-	VOLTO_VERSION=$(VOLTO_VERSION) PLONE_VERSION=$(PLONE_VERSION) docker compose -f docker-compose.yml exec backend ./docker-entrypoint.sh create-site
 
 .PHONY: stack-status
 stack-status:  ## Local Stack: Check Status

--- a/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/README.md
+++ b/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/README.md
@@ -69,8 +69,8 @@ Deploy a local Docker Compose environment that includes the following.
 Run the following commands in a shell session.
 
 ```shell
-make stack-start
 make stack-create-site
+make stack-start
 ```
 
 And... you're all set! Your Plone site is up and running locally! 🚀


### PR DESCRIPTION
This is a variation on @tlotze's work in #257.

Instead of conditionally using `run` or `exec` depending on the db, I made `stack-create-site` always use `run`, with the expectation that `stack-create-site` should always be run before `stack-start`.