### PR TITLE
Update pnpm to 10.13.1

### DIFF
--- a/templates/add-ons/frontend/cookiecutter.json
+++ b/templates/add-ons/frontend/cookiecutter.json
@@ -18,7 +18,7 @@
   "__version_plone_volto": "{{ cookiecutter.volto_version }}",
   "__version_plone_scripts": "^3.6.1",
   "__version_mrs_developer": "^2.2.0",
-  "__version_pnpm": "9.1.1",
+  "__version_pnpm": "10.13.1",
   "__version_release_it": "^17.1.1",
   "__node_version": "{{ cookiecutter.volto_version | node_version_for_volto }}",
   "__gha_version_node": "{{ cookiecutter.__node_version }}",

--- a/templates/add-ons/frontend/{{ cookiecutter.__folder_name }}/package.json
+++ b/templates/add-ons/frontend/{{ cookiecutter.__folder_name }}/package.json
@@ -44,7 +44,20 @@
     "overrides": {
       "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
       "react-refresh": "^0.14.2"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "@swc/core",
+      "core-js",
+      "core-js-pure",
+      "cypress",
+      "es5-ext",
+      "esbuild",
+      "full-icu",
+      "why"
+    ],
+    "onlyBuiltDependencies": [
+      "lightningcss-cli"
+    ]
   },
   "packageManager": "pnpm@{{ cookiecutter.__version_pnpm }}"
 }

--- a/templates/projects/monorepo/cookiecutter.json
+++ b/templates/projects/monorepo/cookiecutter.json
@@ -32,7 +32,7 @@
   "__python_version": "3.12",
   "__node_version": "{{ cookiecutter.volto_version | node_version_for_volto }}",
   "__version_plone_volto": "{{ cookiecutter.volto_version }}",
-  "__version_pnpm": "9.1.1",
+  "__version_pnpm": "10.13.1",
   "__container_registry_prefix": "{{ cookiecutter.container_registry | image_prefix }}",
   "__container_image_prefix": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
   "__profile_version": "{% now 'utc', '%Y%m%d001' %}",

--- a/templates/sub/frontend_project/{{ cookiecutter.__folder_name }}/_project_files/package.json
+++ b/templates/sub/frontend_project/{{ cookiecutter.__folder_name }}/_project_files/package.json
@@ -42,7 +42,20 @@
     "overrides": {
       "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
       "react-refresh": "^0.14.2"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "@swc/core",
+      "core-js",
+      "core-js-pure",
+      "cypress",
+      "es5-ext",
+      "esbuild",
+      "full-icu",
+      "why"
+    ],
+    "onlyBuiltDependencies": [
+      "lightningcss-cli"
+    ]
   },
   "packageManager": "pnpm@10.13.1"
 }

--- a/templates/sub/frontend_project/{{ cookiecutter.__folder_name }}/_project_files/package.json
+++ b/templates/sub/frontend_project/{{ cookiecutter.__folder_name }}/_project_files/package.json
@@ -44,5 +44,5 @@
       "react-refresh": "^0.14.2"
     }
   },
-  "packageManager": "pnpm@9.1.1"
+  "packageManager": "pnpm@10.13.1"
 }

--- a/templates/sub/project_settings/cookiecutter.json
+++ b/templates/sub/project_settings/cookiecutter.json
@@ -33,7 +33,7 @@
   "__version_plone_volto": "{{ cookiecutter.volto_version }}",
   "__version_plone_scripts": "^3.6.1",
   "__version_mrs_developer": "^2.2.0",
-  "__version_pnpm": "9.1.1",
+  "__version_pnpm": "10.13.1",
   "__version_release_it": "^17.1.1",
   "_copy_without_render": [],
   "_extensions": [

--- a/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/frontend/package.json
+++ b/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/frontend/package.json
@@ -44,7 +44,20 @@
     "overrides": {
       "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
       "react-refresh": "^0.14.2"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "@swc/core",
+      "core-js",
+      "core-js-pure",
+      "cypress",
+      "es5-ext",
+      "esbuild",
+      "full-icu",
+      "why"
+    ],
+    "onlyBuiltDependencies": [
+      "lightningcss-cli"
+    ]
   },
   "packageManager": "pnpm@{{ cookiecutter.__version_pnpm }}"
 }


### PR DESCRIPTION
`pnpm` version 10 fixes several security issues.

`pnpm` 10.x introduced a security feature that requires explicit approval to run postinstall scripts. Without approval, `lightningcss-cli` creates a placeholder text file instead of the actual binary, breaking CSS builds.

- Add `ignoredBuiltDependencies` to prevent unnecessary build scripts
- Add `onlyBuiltDependencies` to automatically approve `lightningcss-cli`
- Eliminates manual 'pnpm approve-builds' requirement for CSS builds
- Ensures `lightningcss` binary is properly installed during pnpm install
- Prevents build script warnings in clean installs

This configuration maintains security while enabling automated builds by explicitly controlling which packages can execute postinstall scripts.