### PR TITLE
Respects Python version when installing backend in project

### DIFF
--- a/news/+python-project.bugfix
+++ b/news/+python-project.bugfix
@@ -1,0 +1,1 @@
+Respects Python version when installing backend in project. @wesleybl

--- a/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/Makefile
+++ b/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/Makefile
@@ -58,7 +58,7 @@ frontend-test:  ## Test frontend codebase
 ###########################################
 .PHONY: backend-install
 backend-install:  ## Create virtualenv and install Plone
-	$(MAKE) -C "./backend/" install
+	cd ./backend/ && $(MAKE) install && cd ..
 	$(MAKE) backend-create-site
 
 .PHONY: backend-build


### PR DESCRIPTION
After #265, bug #254 returned.

The backend addon's `@uv venv $(VENV_FOLDER)` command respects the Python version in `pyproject.toml`. But the project's `make install` command is executed in the context of the project root, where we don't have `pyproject.toml`. This did that the version of Python used was the system version, not the version required by the project. So we need to enter the backend folder, so that `uv` fills `pyproject.toml`.

Closes #254 
