### PR TITLE
Be explicit about the Python version when running uv venv locally in backend

### DIFF
--- a/news/+python-version.bugfix
+++ b/news/+python-version.bugfix
@@ -1,0 +1,1 @@
+Be explicit about the Python version when running uv venv locally in backend. @wesleybl

--- a/templates/add-ons/backend/{{ cookiecutter.__folder_name }}/Makefile
+++ b/templates/add-ons/backend/{{ cookiecutter.__folder_name }}/Makefile
@@ -54,7 +54,11 @@ requirements-mxdev.txt: pyproject.toml mx.ini ## Generate constraints file
 
 $(VENV_FOLDER): requirements-mxdev.txt ## Install dependencies
 	@echo "$(GREEN)==> Install environment$(RESET)"
+ifdef CI
 	@uv venv $(VENV_FOLDER)
+else
+	@uv venv --python={{ cookiecutter.__supported_versions_python[0] }} $(VENV_FOLDER)
+endif
 	@uv pip install -r requirements-mxdev.txt
 
 .PHONY: sync

--- a/templates/sub/classic_project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/templates/sub/classic_project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -54,7 +54,11 @@ requirements-mxdev.txt: pyproject.toml mx.ini ## Generate constraints file
 
 $(VENV_FOLDER): requirements-mxdev.txt ## Install dependencies
 	@echo "$(GREEN)==> Install environment$(RESET)"
+ifdef CI
 	@uv venv $(VENV_FOLDER)
+else
+	@uv venv --python={{ cookiecutter.__supported_versions_python[0] }} $(VENV_FOLDER)
+endif
 	@uv pip install -r requirements-mxdev.txt
 
 .PHONY: sync

--- a/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -54,7 +54,11 @@ requirements-mxdev.txt: pyproject.toml mx.ini ## Generate constraints file
 
 $(VENV_FOLDER): requirements-mxdev.txt ## Install dependencies
 	@echo "$(GREEN)==> Install environment$(RESET)"
+ifdef CI
 	@uv venv $(VENV_FOLDER)
+else
+	@uv venv --python={{ cookiecutter.__supported_versions_python[0] }} $(VENV_FOLDER)
+endif
 	@uv pip install -r requirements-mxdev.txt
 
 .PHONY: sync


### PR DESCRIPTION
After https://github.com/plone/cookieplone-templates/pull/265, bug https://github.com/plone/cookieplone-templates/issues/254 returned.

When we are in CI, we use the system version, so that packages can be tested on multiple Python versions.

Ref #255

Fix #254