### PR TITLE
feat: Hide the upgrades package from site-creation and quickinstaller

### DIFF
--- a/news/285.feature
+++ b/news/285.feature
@@ -1,0 +1,1 @@
+Hide the upgrades package from site-creation and quickinstaller @erral

--- a/templates/add-ons/backend/{{ cookiecutter.__folder_name }}/src/packagename/setuphandlers/__init__.py
+++ b/templates/add-ons/backend/{{ cookiecutter.__folder_name }}/src/packagename/setuphandlers/__init__.py
@@ -9,3 +9,10 @@ class HiddenProfiles:
         return [
             "{{ cookiecutter.python_package_name }}:uninstall",
         ]
+
+    def getNonInstallableProducts(self):
+        """Hide the upgrades package from site-creation and quickinstaller."""
+        return [
+            "{{ cookiecutter.python_package_name }}:upgrades",
+        ]
+

--- a/templates/add-ons/backend/{{ cookiecutter.__folder_name }}/src/packagename/setuphandlers/__init__.py
+++ b/templates/add-ons/backend/{{ cookiecutter.__folder_name }}/src/packagename/setuphandlers/__init__.py
@@ -13,6 +13,6 @@ class HiddenProfiles:
     def getNonInstallableProducts(self):
         """Hide the upgrades package from site-creation and quickinstaller."""
         return [
-            "{{ cookiecutter.python_package_name }}:upgrades",
+            "{{ cookiecutter.python_package_name }}.upgrades",
         ]
 


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

We did this previously in bobtemplates.plone: https://github.com/plone/bobtemplates.plone/blob/6.x/bobtemplates/plone/addon/src/%2Bpackage.namespace%2B/%2Bpackage.name%2B/setuphandlers.py.bob#L15-L17

