### PR TITLE
Support for `razzle-scss-plugin` in core

### DIFF
--- a/news/+scssrazzlepluginincore.feature
+++ b/news/+scssrazzlepluginincore.feature
@@ -1,0 +1,1 @@
+Volto 19 has adopted `razzle-scss-plugin` in core. @sneridagh

--- a/templates/add-ons/frontend/{{ cookiecutter.__folder_name }}/.storybook/main.js
+++ b/templates/add-ons/frontend/{{ cookiecutter.__folder_name }}/.storybook/main.js
@@ -5,8 +5,11 @@ const path = require('path');
 const projectRootPath = path.resolve('.');
 const lessPlugin = require('@plone/volto/webpack-plugins/webpack-less-plugin');
 const RelativeResolverPlugin = require('@plone/volto/webpack-plugins/webpack-relative-resolver');
+{%- if cookiecutter.volto_version >= '19' %}
+const scssPlugin = require('@plone/volto/webpack-plugins/webpack-scss-plugin');
+{%- else %}
 const scssPlugin = require('razzle-plugin-scss');
-
+{%- endif %}
 const createConfig = require('razzle/config/createConfigAsync.js');
 const razzleConfig = require(path.join(projectRootPath, 'razzle.config.js'));
 


### PR DESCRIPTION
The pre-release Storybook build will fail until https://github.com/plone/volto/pull/7188 is not merged and vice-versa.