### PR TITLE
Catalog support for 19 builds.

### DIFF
--- a/news/+catalogSupport.feature
+++ b/news/+catalogSupport.feature
@@ -1,0 +1,1 @@
+Catalog support for Volto 19 projects. @sneridagh

--- a/templates/add-ons/frontend/hooks/post_gen_project.py
+++ b/templates/add-ons/frontend/hooks/post_gen_project.py
@@ -43,6 +43,9 @@ def remove_conditional_files(context, output_dir):
     else:
         (output_dir / "jest-addon.config.js").unlink()
 
+    if context["volto_version"] < "19":
+        (output_dir / ".pnpmfile.cjs").unlink()
+
 
 def main():
     """Final fixes."""

--- a/templates/add-ons/frontend/{{ cookiecutter.__folder_name }}/.pnpmfile.cjs
+++ b/templates/add-ons/frontend/{{ cookiecutter.__folder_name }}/.pnpmfile.cjs
@@ -1,0 +1,23 @@
+/* eslint-disable */
+const fs = require('fs');
+const path = require('path');
+
+const catalogPath = path.resolve(__dirname, 'core/catalog.json');
+let catalog = {};
+if (fs.existsSync(catalogPath)) {
+  const catalogData = fs.readFileSync(catalogPath, 'utf-8');
+  catalog = JSON.parse(catalogData);
+} else {
+  console.error('Catalog file does not exist at:', catalogPath);
+}
+
+module.exports = {
+  hooks: {
+    updateConfig(config) {
+      if (config.catalogs) {
+        config.catalogs.default ??= catalog;
+      }
+      return config;
+    },
+  },
+};


### PR DESCRIPTION
@davisagli @ericof 

This is a small change, but it can be annoying, as soon we would start using the catalog in core (because everybody would have to add this file in their projects, otherwise, the build will fail when it finds a "catalog:" entry.

So, I have two proposals I already mentioned to you before.

The first one, is that we need to streamline the "re-generation" of projects, by saving the data somewhere (cookiecutter replay file would be ok). We tap into it, we assign a known place in the generated project, that we later re-read on demand, replay cookieplone with it. We could use repoplone for it, or just cookieplone command line.

Second, is that maybe we can write "upgrade steps" for cookieplone? Given a local version of the generated files (based on date, for example), we run all the pending upgrade steps, in a GS fashion. `make upgrade`, or `uvx repoplone upgrade` What do you think?