### PR TITLE
Replace the usage of from Products.CMFPlone.interfaces import INonInstallable

### DIFF
--- a/news/327.bugfix
+++ b/news/327.bugfix
@@ -1,0 +1,1 @@
+Replace the usage of from Products.CMFPlone.interfaces import INonInstallable by from plone.base.interfaces.installable import INonInstallable in the backend add-on template. @ericof

--- a/templates/add-ons/backend/{{ cookiecutter.__folder_name }}/src/packagename/setuphandlers/__init__.py
+++ b/templates/add-ons/backend/{{ cookiecutter.__folder_name }}/src/packagename/setuphandlers/__init__.py
@@ -1,4 +1,4 @@
-from Products.CMFPlone.interfaces import INonInstallable
+from plone.base.interfaces.installable import INonInstallable
 from zope.interface import implementer
 
 
@@ -15,4 +15,3 @@ class HiddenProfiles:
         return [
             "{{ cookiecutter.python_package_name }}.upgrades",
         ]
-


### PR DESCRIPTION
by from plone.base.interfaces.installable import INonInstallable in the backend add-on template.

Fixes #327
