### PR TITLE
Fix varnish CI.

### DIFF
--- a/news/+7678e301.bugfix.md
+++ b/news/+7678e301.bugfix.md
@@ -1,0 +1,1 @@
+Fix varnish CI. @mauritsvanrees

--- a/templates/ci/gh_classic_project/{{ cookiecutter.__folder_name }}/workflows/config.yml
+++ b/templates/ci/gh_classic_project/{{ cookiecutter.__folder_name }}/workflows/config.yml
@@ -18,6 +18,9 @@ on:
       backend:
         description: "Flag reporting if we should run the backend jobs"
         value: {{ "${{ jobs.config.outputs.backend }}" }}
+      cache:
+        description: "Flag reporting if we should run the cache jobs"
+        value: {{ "${{ jobs.config.outputs.cache }}" }}
       devops:
         description: "Flag reporting if we should run the devops jobs"
         value: {{ "${{ jobs.config.outputs.devops }}" }}
@@ -43,6 +46,7 @@ jobs:
     outputs:
       acceptance: {{ "${{ steps.filter.outputs.acceptance }}" }}
       backend: {{ "${{ steps.filter.outputs.backend }}" }}
+      cache: {{ "${{ steps.filter.outputs.cache }}" }}
       devops: {{ "${{ steps.filter.outputs.devops }}" }}
       docs: {{ "${{ steps.filter.outputs.docs }}" }}
       base-tag: {{ "${{ steps.vars.outputs.base-tag }}" }}
@@ -69,6 +73,9 @@ jobs:
             backend:
               - 'backend/**'
               - '.github/workflows/backend*'
+            cache:
+              - 'devops/varnish/**'
+              - '.github/workflows/varnish*'
             devops:
               - 'devops/**'
             docs:
@@ -83,5 +90,6 @@ jobs:
           echo 'event-name: {{ "${{ github.event_name }}" }}'
           echo 'Paths - acceptance: {{ "${{ steps.filter.outputs.acceptance }}" }}'
           echo 'Paths - backend: {{ "${{ steps.filter.outputs.backend }}" }}'
+          echo 'Paths - cache: {{ "${{ steps.filter.outputs.cache }}" }}'
           echo 'Paths - devops: {{ "${{ steps.filter.outputs.devops }}" }}'
           echo 'Paths - docs: {{ "${{ steps.filter.outputs.docs }}" }}'

--- a/templates/ci/gh_classic_project/{{ cookiecutter.__folder_name }}/workflows/main.yml
+++ b/templates/ci/gh_classic_project/{{ cookiecutter.__folder_name }}/workflows/main.yml
@@ -57,6 +57,9 @@ jobs:
         image-name-prefix: {{ "${{ needs.config.outputs.image-name-prefix }}" }}
         image-name-suffix: varnish
     if: {{ "${{ needs.config.outputs.cache == 'true' }}" }}
+    permissions:
+      contents: read
+      packages: write
   {%- endif %}
 
   report:

--- a/templates/ci/gh_project/{{ cookiecutter.__folder_name }}/workflows/config.yml
+++ b/templates/ci/gh_project/{{ cookiecutter.__folder_name }}/workflows/config.yml
@@ -22,6 +22,9 @@ on:
       backend:
         description: "Flag reporting if we should run the backend jobs"
         value: {{ "${{ jobs.config.outputs.backend }}" }}
+      cache:
+        description: "Flag reporting if we should run the cache jobs"
+        value: {{ "${{ jobs.config.outputs.cache }}" }}
       devops:
         description: "Flag reporting if we should run the devops jobs"
         value: {{ "${{ jobs.config.outputs.devops }}" }}
@@ -56,6 +59,7 @@ jobs:
     outputs:
       acceptance: {{ "${{ steps.filter.outputs.acceptance }}" }}
       backend: {{ "${{ steps.filter.outputs.backend }}" }}
+      cache: {{ "${{ steps.filter.outputs.cache }}" }}
       devops: {{ "${{ steps.filter.outputs.devops }}" }}
       docs: {{ "${{ steps.filter.outputs.docs }}" }}
       frontend: {{ "${{ steps.filter.outputs.frontend }}" }}
@@ -86,6 +90,9 @@ jobs:
             backend:
               - 'backend/**'
               - '.github/workflows/backend*'
+            cache:
+              - 'devops/varnish/**'
+              - '.github/workflows/varnish*'
             devops:
               - 'devops/**'
             docs:
@@ -104,6 +111,7 @@ jobs:
           echo 'event-name: {{ "${{ github.event_name }}" }}'
           echo 'Paths - acceptance: {{ "${{ steps.filter.outputs.acceptance }}" }}'
           echo 'Paths - backend: {{ "${{ steps.filter.outputs.backend }}" }}'
+          echo 'Paths - cache: {{ "${{ steps.filter.outputs.cache }}" }}'
           echo 'Paths - devops: {{ "${{ steps.filter.outputs.devops }}" }}'
           echo 'Paths - docs: {{ "${{ steps.filter.outputs.docs }}" }}'
           echo 'Paths - frontend: {{ "${{ steps.filter.outputs.frontend }}" }}'

--- a/templates/ci/gh_project/{{ cookiecutter.__folder_name }}/workflows/main.yml
+++ b/templates/ci/gh_project/{{ cookiecutter.__folder_name }}/workflows/main.yml
@@ -58,6 +58,9 @@ jobs:
         image-name-prefix: {{ "${{ needs.config.outputs.image-name-prefix }}" }}
         image-name-suffix: varnish
     if: {{ "${{ needs.config.outputs.cache == 'true' }}" }}
+    permissions:
+      contents: read
+      packages: write
   {%- endif %}
 
   frontend:


### PR DESCRIPTION
The `packages: write` permission was not set in `main.yml` so the nested jobs did not have this permission:

```
The workflow is not valid.
.github/workflows/main.yml (Line: 34, Col: 3):
Error calling workflow '.../.github/workflows/varnish.yml@757de83a97f2630c8e6f5050ea7e9afd4a48ffa1'.
The nested job 'release' is requesting 'packages: write', but is only allowed 'packages: read'.
```

And the varnish job was only run when `steps.filter.outputs.cache` was true, but this output was never set.

Fix copied from a (Volto) project that I generated at the end of last week. Copied to the Classic UI project scaffold as well.
