### PR TITLE
Flexible docker image name generation depending on the container registry

### DIFF
--- a/news/+flexible_image_naming.feature
+++ b/news/+flexible_image_naming.feature
@@ -1,0 +1,1 @@
+Flexible docker image name generation depending on the container registry.

--- a/templates/add-ons/monorepo/cookieplone.json
+++ b/templates/add-ons/monorepo/cookieplone.json
@@ -230,10 +230,17 @@
                 "validator": "",
                 "format": "computed"
             },
+            "__container_registry_prefix_separator": {
+                "type": "string",
+                "title": "__container_registry_prefix_separator",
+                "default": "{{ '/' if cookiecutter.container_registry == 'gitlab' else '-' }}",
+                "validator": "",
+                "format": "computed"
+            },
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/add-ons/monorepo/{{ cookiecutter.__folder_name }}/Makefile
+++ b/templates/add-ons/monorepo/{{ cookiecutter.__folder_name }}/Makefile
@@ -207,12 +207,12 @@ acceptance-test:
 .PHONY: acceptance-frontend-image-build
 acceptance-frontend-image-build:
 	@echo "Build acceptance frontend image"
-	@docker build frontend -t $(IMAGE_NAME_PREFIX)-frontend:acceptance -f frontend/Dockerfile --build-arg VOLTO_VERSION=$(VOLTO_VERSION)
+	@docker build frontend -t $(IMAGE_NAME_PREFIX)frontend:acceptance -f frontend/Dockerfile --build-arg VOLTO_VERSION=$(VOLTO_VERSION)
 
 .PHONY: acceptance-backend-image-build
 acceptance-backend-image-build:
 	@echo "Build acceptance backend image"
-	@docker build backend -t $(IMAGE_NAME_PREFIX)-backend:acceptance -f backend/Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
+	@docker build backend -t $(IMAGE_NAME_PREFIX)backend:acceptance -f backend/Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
 
 .PHONY: acceptance-images-build
 acceptance-images-build: ## Build Acceptance frontend/backend images
@@ -222,12 +222,12 @@ acceptance-images-build: ## Build Acceptance frontend/backend images
 .PHONY: acceptance-frontend-container-start
 acceptance-frontend-container-start:
 	@echo "Start acceptance frontend"
-	@docker run --rm -p 3000:3000 --name $(IMAGE_NAME_PREFIX)-frontend-acceptance --link $(IMAGE_NAME_PREFIX)-backend-acceptance:backend -e RAZZLE_API_PATH=http://localhost:55001/plone -e RAZZLE_INTERNAL_API_PATH=http://backend:55001/plone -d $(IMAGE_NAME_PREFIX)-frontend:acceptance
+	@docker run --rm -p 3000:3000 --name $(IMAGE_NAME_PREFIX)frontend-acceptance --link $(IMAGE_NAME_PREFIX)backend-acceptance:backend -e RAZZLE_API_PATH=http://localhost:55001/plone -e RAZZLE_INTERNAL_API_PATH=http://backend:55001/plone -d $(IMAGE_NAME_PREFIX)frontend:acceptance
 
 .PHONY: acceptance-backend-container-start
 acceptance-backend-container-start:
 	@echo "Start acceptance backend"
-	@docker run --rm -p 55001:55001 --name $(IMAGE_NAME_PREFIX)-backend-acceptance -d $(IMAGE_NAME_PREFIX)-backend:acceptance
+	@docker run --rm -p 55001:55001 --name $(IMAGE_NAME_PREFIX)backend-acceptance -d $(IMAGE_NAME_PREFIX)backend:acceptance
 
 .PHONY: acceptance-containers-start
 acceptance-containers-start: ## Start Acceptance containers
@@ -237,8 +237,8 @@ acceptance-containers-start: ## Start Acceptance containers
 .PHONY: acceptance-containers-stop
 acceptance-containers-stop: ## Stop Acceptance containers
 	@echo "Stop acceptance containers"
-	@docker stop $(IMAGE_NAME_PREFIX)-frontend-acceptance
-	@docker stop $(IMAGE_NAME_PREFIX)-backend-acceptance
+	@docker stop $(IMAGE_NAME_PREFIX)frontend-acceptance
+	@docker stop $(IMAGE_NAME_PREFIX)backend-acceptance
 
 .PHONY: ci-acceptance-test
 ci-acceptance-test:

--- a/templates/devops/ansible/cookieplone.json
+++ b/templates/devops/ansible/cookieplone.json
@@ -201,10 +201,17 @@
                 "validator": "",
                 "format": "computed"
             },
+            "__container_registry_prefix_separator": {
+                "type": "string",
+                "title": "__container_registry_prefix_separator",
+                "default": "{{ '/' if cookiecutter.container_registry == 'gitlab' else '-' }}",
+                "validator": "",
+                "format": "computed"
+            },
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.organization }}/{{ cookiecutter.__project_slug }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.organization }}/{{ cookiecutter.__project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/projects/classic/cookieplone.json
+++ b/templates/projects/classic/cookieplone.json
@@ -220,10 +220,17 @@
                 "validator": "",
                 "format": "computed"
             },
+            "__container_registry_prefix_separator": {
+                "type": "string",
+                "title": "__container_registry_prefix_separator",
+                "default": "{{ '/' if cookiecutter.container_registry == 'gitlab' else '-' }}",
+                "validator": "",
+                "format": "computed"
+            },
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/projects/classic/{{ cookiecutter.__folder_name }}/devops/stacks/{{ cookiecutter.hostname }}.yml
+++ b/templates/projects/classic/{{ cookiecutter.__folder_name }}/devops/stacks/{{ cookiecutter.hostname }}.yml
@@ -99,7 +99,7 @@ services:
         order: start-first
 
   varnish:
-    image: {{ cookiecutter.__container_image_prefix }}-varnish:${STACK_PARAM:-latest}
+    image: {{ cookiecutter.__container_image_prefix }}varnish:${STACK_PARAM:-latest}
     command:
       - '-p'
       - 'nuke_limit=2000'
@@ -134,7 +134,7 @@ services:
 {%- endif %}
 
   backend:
-    image: {{ cookiecutter.__container_image_prefix }}-backend:${STACK_PARAM:-latest}
+    image: {{ cookiecutter.__container_image_prefix }}backend:${STACK_PARAM:-latest}
 {%- if cookiecutter.devops_storage == 'relstorage' %}
     environment:
       RELSTORAGE_DSN: "dbname='${DB_NAME:-plone}' user='${DB_USER:-plone}' host='${DB_HOST:-db}' password='${DB_PASSWORD:-{{ cookiecutter.__devops_db_password }}}' port='${DB_PORT:-5432}'"

--- a/templates/projects/monorepo/cookieplone.json
+++ b/templates/projects/monorepo/cookieplone.json
@@ -314,10 +314,17 @@
                 "validator": "",
                 "format": "computed"
             },
+            "__container_registry_prefix_separator": {
+                "type": "string",
+                "title": "__container_registry_prefix_separator",
+                "default": "{{ '/' if cookiecutter.container_registry == 'gitlab' else '-' }}",
+                "validator": "",
+                "format": "computed"
+            },
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/devops/README-GHA.md
+++ b/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/devops/README-GHA.md
@@ -51,7 +51,7 @@ Ensure that both Backend and Frontend tests have been successfully executed:
 - [Backend Tests Workflow]({{ cookiecutter.__repository_url }}/actions/workflows/backend.yml)
 - [Frontend Tests Workflow]({{ cookiecutter.__repository_url }}/actions/workflows/frontend.yml)
 
-Upon successful completion of the tests, Docker images for the Backend (`{{ cookiecutter.__container_image_prefix }}-backend`) and Frontend (`{{ cookiecutter.__container_image_prefix }}-frontend`) will be available.
+Upon successful completion of the tests, Docker images for the Backend (`{{ cookiecutter.__container_image_prefix }}backend`) and Frontend (`{{ cookiecutter.__container_image_prefix }}frontend`) will be available.
 
 ### Initiating Manual Deployment
 

--- a/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/devops/stacks/{{ cookiecutter.hostname }}.yml
+++ b/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/devops/stacks/{{ cookiecutter.hostname }}.yml
@@ -99,7 +99,7 @@ services:
         order: start-first
 
   varnish:
-    image: {{ cookiecutter.__container_image_prefix }}-varnish:${STACK_PARAM:-latest}
+    image: {{ cookiecutter.__container_image_prefix }}varnish:${STACK_PARAM:-latest}
     command:
       - '-p'
       - 'nuke_limit=2000'
@@ -135,7 +135,7 @@ services:
 {%- endif %}
 
   frontend:
-    image: {{ cookiecutter.__container_image_prefix }}-frontend:${STACK_PARAM:-latest}
+    image: {{ cookiecutter.__container_image_prefix }}frontend:${STACK_PARAM:-latest}
     environment:
       RAZZLE_INTERNAL_API_PATH: http://backend:8080/Plone
       RAZZLE_API_PATH: https://{{ cookiecutter.hostname }}
@@ -172,7 +172,7 @@ services:
 {%- endif %}
 
   backend:
-    image: {{ cookiecutter.__container_image_prefix }}-backend:${STACK_PARAM:-latest}
+    image: {{ cookiecutter.__container_image_prefix }}backend:${STACK_PARAM:-latest}
 {%- if cookiecutter.devops_storage == 'relstorage' %}
     environment:
       RELSTORAGE_DSN: "dbname='${DB_NAME:-plone}' user='${DB_USER:-plone}' host='${DB_HOST:-db}' password='${DB_PASSWORD:-{{ cookiecutter.__devops_db_password }}}' port='${DB_PORT:-5432}'"

--- a/templates/sub/addon_settings/cookieplone.json
+++ b/templates/sub/addon_settings/cookieplone.json
@@ -166,10 +166,17 @@
                 "validator": "",
                 "format": "computed"
             },
+            "__container_registry_prefix_separator": {
+                "type": "string",
+                "title": "__container_registry_prefix_separator",
+                "default": "{{ '/' if cookiecutter.container_registry == 'gitlab' else '-' }}",
+                "validator": "",
+                "format": "computed"
+            },
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/sub/addon_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/templates/sub/addon_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -26,7 +26,7 @@ endif
 REPOSITORY_SETTINGS := $(shell uvx repoplone settings dump)
 IMAGE_NAME_PREFIX := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.container_images_prefix')
 IMAGE_TAG=latest
-IMAGE_NAME=$(IMAGE_NAME_PREFIX)-backend:$(IMAGE_TAG)
+IMAGE_NAME=$(IMAGE_NAME_PREFIX)backend:$(IMAGE_TAG)
 
 PLONE_SITE_ID=Plone
 BACKEND_FOLDER=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
@@ -164,7 +164,7 @@ acceptance-backend-start: ## Start backend acceptance server
 
 .PHONY: acceptance-image-build
 acceptance-image-build:  ## Build Docker Images
-	@docker build . -t $(IMAGE_NAME_PREFIX)-backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
+	@docker build . -t $(IMAGE_NAME_PREFIX)backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
 
 ## Add bobtemplates features (check bobtemplates.plone's documentation to get the list of available features)
 add: $(VENV_FOLDER)

--- a/templates/sub/addon_settings/{{ cookiecutter.__folder_name }}/frontend/Makefile
+++ b/templates/sub/addon_settings/{{ cookiecutter.__folder_name }}/frontend/Makefile
@@ -27,7 +27,7 @@ DOCKER_IMAGE_ACCEPTANCE=plone/server-acceptance:${PLONE_VERSION}
 ADDON_NAME := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.frontend.name')
 IMAGE_NAME_PREFIX := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.container_images_prefix')
 IMAGE_TAG=latest
-IMAGE_NAME=$(IMAGE_NAME_PREFIX)-frontend:$(IMAGE_TAG)
+IMAGE_NAME=$(IMAGE_NAME_PREFIX)frontend:$(IMAGE_TAG)
 
 # Environment variables to be exported
 export VOLTO_VERSION := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.frontend.volto_version')

--- a/templates/sub/classic_project_settings/cookieplone.json
+++ b/templates/sub/classic_project_settings/cookieplone.json
@@ -129,10 +129,17 @@
                 "validator": "",
                 "format": "computed"
             },
+            "__container_registry_prefix_separator": {
+                "type": "string",
+                "title": "__container_registry_prefix_separator",
+                "default": "{{ '/' if cookiecutter.container_registry == 'gitlab' else '-' }}",
+                "validator": "",
+                "format": "computed"
+            },
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/sub/classic_project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/templates/sub/classic_project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -139,7 +139,7 @@ test-coverage: $(VENV_FOLDER) ## run tests with coverage
 # Build Docker images
 .PHONY: build-image
 build-image:  ## Build Docker Images
-	@docker build . -t $(IMAGE_NAME_PREFIX)-backend:$(IMAGE_TAG) -f Dockerfile --build-arg PLONE_VERSION=$(PLONE_VERSION)
+	@docker build . -t $(IMAGE_NAME_PREFIX)backend:$(IMAGE_TAG) -f Dockerfile --build-arg PLONE_VERSION=$(PLONE_VERSION)
 
 # Acceptance tests
 .PHONY: acceptance-backend-start
@@ -148,7 +148,7 @@ acceptance-backend-start: ## Start backend acceptance server
 
 .PHONY: acceptance-image-build
 acceptance-image-build:  ## Build Docker Images
-	@docker build . -t $(IMAGE_NAME_PREFIX)-backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
+	@docker build . -t $(IMAGE_NAME_PREFIX)backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
 
 ## Add bobtemplates features (check bobtemplates.plone's documentation to get the list of available features)
 add: $(VENV_FOLDER)

--- a/templates/sub/project_settings/cookieplone.json
+++ b/templates/sub/project_settings/cookieplone.json
@@ -164,10 +164,17 @@
                 "validator": "",
                 "format": "computed"
             },
+            "__container_registry_prefix_separator": {
+                "type": "string",
+                "title": "__container_registry_prefix_separator",
+                "default": "{{ '/' if cookiecutter.container_registry == 'gitlab' else '-' }}",
+                "validator": "",
+                "format": "computed"
+            },
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -29,7 +29,7 @@ endif
 REPOSITORY_SETTINGS := $(shell uvx repoplone settings dump)
 IMAGE_NAME_PREFIX := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.container_images_prefix')
 IMAGE_TAG=latest
-IMAGE_NAME=$(IMAGE_NAME_PREFIX)-backend:$(IMAGE_TAG)
+IMAGE_NAME=$(IMAGE_NAME_PREFIX)backend:$(IMAGE_TAG)
 
 PLONE_SITE_ID=Plone
 BACKEND_FOLDER=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
@@ -175,7 +175,7 @@ acceptance-backend-start: ## Start backend acceptance server
 
 .PHONY: acceptance-image-build
 acceptance-image-build:  ## Build Docker Images
-	@docker build . -t $(IMAGE_NAME_PREFIX)-backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
+	@docker build . -t $(IMAGE_NAME_PREFIX)backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
 
 ############################################
 # Plone CLI

--- a/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/frontend/Makefile
+++ b/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/frontend/Makefile
@@ -29,7 +29,7 @@ DOCKER_IMAGE_ACCEPTANCE=plone/server-acceptance:${PLONE_VERSION}
 
 ADDON_NAME := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.frontend.name')
 IMAGE_NAME_PREFIX := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.container_images_prefix')
-IMAGE_NAME=$(IMAGE_NAME_PREFIX)-frontend
+IMAGE_NAME=$(IMAGE_NAME_PREFIX)frontend
 IMAGE_TAG=latest
 
 

--- a/tests/cookieplone-templates/test_templates.py
+++ b/tests/cookieplone-templates/test_templates.py
@@ -43,7 +43,8 @@ def test_all_templates_should_be_listed(all_templates, templates_by_path):
         ),
         (
             "sub/classic_project_settings",
-            "Project settings to be applied on top of a Plone 6 using Classic UI project",
+            "Project settings to be applied on top of a Plone 6 using "
+            "Classic UI project",
             True,
         ),
         (

--- a/tests/templates/add-ons/monorepo/test_monorepo_images.py
+++ b/tests/templates/add-ons/monorepo/test_monorepo_images.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "registry,expected_prefix,expected_separator",
+    [
+        ("github", "ghcr.io/collective/collective-addon-", "-"),
+        ("gitlab", "registry.gitlab.com/collective/collective-addon/", "/"),
+        ("docker_hub", "collective/collective-addon-", "-"),
+    ],
+)
+def test_monorepo_addon_image_prefix_registry(
+    cookies, template_path, context, registry, expected_prefix, expected_separator
+):
+    """Test image prefix for different registries in Monorepo Add-on template."""
+    context["container_registry"] = registry
+    result = cookies.bake(extra_context=context, template=template_path)
+
+    assert result.exception is None
+    assert result.exit_code == 0
+    assert result.context["__container_registry_prefix_separator"] == expected_separator
+    assert result.context["__container_image_prefix"] == expected_prefix
+
+    # Check repository.toml
+    repository_toml = result.project_path / "repository.toml"
+    assert (
+        f'container_images_prefix = "{expected_prefix}"' in repository_toml.read_text()
+    )
+
+    # Check root Makefile
+    root_makefile = result.project_path / "Makefile"
+    # In monorepo addon, acceptance images use IMAGE_NAME_PREFIX
+    assert "$(IMAGE_NAME_PREFIX)frontend:acceptance" in root_makefile.read_text()
+    assert "$(IMAGE_NAME_PREFIX)-frontend:acceptance" not in root_makefile.read_text()

--- a/tests/templates/ide/vscode/test_ide_vscode_cutter_monorepo_addon.py
+++ b/tests/templates/ide/vscode/test_ide_vscode_cutter_monorepo_addon.py
@@ -1,7 +1,5 @@
 """Test cookieplone generation."""
 
-import json
-
 import pytest
 
 

--- a/tests/templates/ide/vscode/test_ide_vscode_cutter_project .py
+++ b/tests/templates/ide/vscode/test_ide_vscode_cutter_project .py
@@ -1,7 +1,5 @@
 """Test cookieplone generation."""
 
-import json
-
 import pytest
 
 

--- a/tests/templates/projects/classic/test_classic_images.py
+++ b/tests/templates/projects/classic/test_classic_images.py
@@ -1,0 +1,30 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "registry,expected_prefix,expected_separator",
+    [
+        ("github", "ghcr.io/plonegovbr/plone.org.br-", "-"),
+        ("gitlab", "registry.gitlab.com/plonegovbr/plone.org.br/", "/"),
+        ("docker_hub", "plonegovbr/plone.org.br-", "-"),
+    ],
+)
+def test_classic_image_prefix_registry(
+    cookies, template_path, context, registry, expected_prefix, expected_separator
+):
+    """Test image prefix for different registries in Classic UI template."""
+    context["container_registry"] = registry
+    result = cookies.bake(extra_context=context, template=template_path)
+
+    assert result.exception is None
+    assert result.exit_code == 0
+    assert result.context["__container_registry_prefix_separator"] == expected_separator
+    assert result.context["__container_image_prefix"] == expected_prefix
+
+    # Check backend Makefile (from sub/classic_project_settings)
+    backend_makefile = result.project_path / "backend" / "Makefile"
+    # Note: In classic template, the IMAGE_NAME_PREFIX is also set in backend/Makefile
+    assert f"IMAGE_NAME_PREFIX={expected_prefix}" in backend_makefile.read_text()
+    # Ensure no redundant dash
+    assert "$(IMAGE_NAME_PREFIX)backend" in backend_makefile.read_text()
+    assert "$(IMAGE_NAME_PREFIX)-backend" not in backend_makefile.read_text()

--- a/tests/templates/projects/monorepo/test_project_images.py
+++ b/tests/templates/projects/monorepo/test_project_images.py
@@ -1,0 +1,35 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "registry,expected_prefix,expected_separator",
+    [
+        ("github", "ghcr.io/plonegovbr/plone.org.br-", "-"),
+        ("gitlab", "registry.gitlab.com/plonegovbr/plone.org.br/", "/"),
+        ("docker_hub", "plonegovbr/plone.org.br-", "-"),
+    ],
+)
+def test_image_prefix_registry(
+    cookies, template_path, context, registry, expected_prefix, expected_separator
+):
+    """Test image prefix for different registries."""
+    context["container_registry"] = registry
+    result = cookies.bake(extra_context=context, template=template_path)
+
+    assert result.exception is None
+    assert result.exit_code == 0
+    assert result.context["__container_registry_prefix_separator"] == expected_separator
+    assert result.context["__container_image_prefix"] == expected_prefix
+
+    # Check repository.toml
+    repository_toml = result.project_path / "repository.toml"
+    assert (
+        f'container_images_prefix = "{expected_prefix}"' in repository_toml.read_text()
+    )
+
+    # Check Makefile in backend (from sub/project_settings)
+    backend_makefile = result.project_path / "backend" / "Makefile"
+    assert f"IMAGE_NAME_PREFIX={expected_prefix}" in backend_makefile.read_text()
+    # Ensure no redundant dash
+    assert "$(IMAGE_NAME_PREFIX)backend" in backend_makefile.read_text()
+    assert "$(IMAGE_NAME_PREFIX)-backend" not in backend_makefile.read_text()


### PR DESCRIPTION
This PR implements flexible Docker image name generation based on the selected container registry.

Key changes:
- Introduced `__container_registry_prefix_separator` to choose between `-` (GitHub/Docker Hub) and `/` (GitLab).
- Updated `__container_image_prefix` to include the separator.
- Standardized this logic across all project and add-on templates, including subtemplates.
- Removed redundant manual dashes in stack files, Makefiles, and READMEs.
- Added comprehensive tests covering different registries for all main templates.

Verified with pytest (9 new test cases passing).