### PR TITLE
Adds extra [uv] to mxdev

### DIFF
--- a/news/407.bugfix
+++ b/news/407.bugfix
@@ -1,0 +1,1 @@
+Adds extra [uv] to mxdev. @wesleybl

--- a/templates/add-ons/backend/{{ cookiecutter.__folder_name }}/Makefile
+++ b/templates/add-ons/backend/{{ cookiecutter.__folder_name }}/Makefile
@@ -56,7 +56,7 @@ help: ## This help message
 requirements-mxdev.txt: pyproject.toml mx.ini ## Generate constraints file
 	@echo "$(GREEN)==> Generate constraints file$(RESET)"
 	@echo '-c https://dist.plone.org/release/$(PLONE_VERSION)/constraints.txt' > requirements.txt
-	@uvx mxdev -c mx.ini
+	@uvx "mxdev[uv]" -c mx.ini
 
 $(VENV_FOLDER): requirements-mxdev.txt ## Install dependencies
 	@echo "$(GREEN)==> Install environment$(RESET)"

--- a/templates/sub/addon_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/templates/sub/addon_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -70,7 +70,7 @@ debug-settings:  ## Debug settings
 requirements-mxdev.txt: pyproject.toml mx.ini ## Generate constraints file
 	@echo "$(GREEN)==> Generate constraints file$(RESET)"
 	@echo '-c https://dist.plone.org/release/$(PLONE_VERSION)/constraints.txt' > requirements.txt
-	@uvx mxdev -c mx.ini
+	@uvx "mxdev[uv]" -c mx.ini
 
 $(VENV_FOLDER): requirements-mxdev.txt ## Install dependencies
 	@echo "$(GREEN)==> Install environment$(RESET)"

--- a/templates/sub/classic_project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/templates/sub/classic_project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -50,7 +50,7 @@ help: ## This help message
 requirements-mxdev.txt: pyproject.toml mx.ini ## Generate constraints file
 	@echo "$(GREEN)==> Generate constraints file$(RESET)"
 	@echo '-c https://dist.plone.org/release/$(PLONE_VERSION)/constraints.txt' > requirements.txt
-	@uvx mxdev -c mx.ini
+	@uvx "mxdev[uv]" -c mx.ini
 
 $(VENV_FOLDER): requirements-mxdev.txt ## Install dependencies
 	@echo "$(GREEN)==> Install environment$(RESET)"


### PR DESCRIPTION
Required for the `uv` hook which requires `tomlkit`.

Fix:

```
raise RuntimeError("tomlkit is required for the uv hook. Install it with: pip install mxdev[uv]")
```

See: https://github.com/plone/cookieplone-templates/actions/runs/26616623319/job/78433643500?pr=406

