### PR TITLE
Upgrade cookieplone to 2.0.0b2 and switch release-it to uvx towncrier

### DIFF
--- a/news/+cookieplone.internal
+++ b/news/+cookieplone.internal
@@ -1,0 +1,1 @@
+Upgrade cookieplone to version 2.0.0b2. @ericof

--- a/news/404.bugfix
+++ b/news/404.bugfix
@@ -1,0 +1,1 @@
+Use 'uvx towncrier' instead of 'pipx run towncrier' for release-it. @frapell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Collection of templates for Plone integrators to use through Cook
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "cookieplone>=2.0.0a2",
+    "cookieplone>=2.0.0b2",
     "gitpython>=3.1.43",
     "pytest>=8.3.5",
     "pytest-xdist>=3.5.0",

--- a/templates/add-ons/frontend/{{ cookiecutter.__folder_name }}/packages/{{ cookiecutter.frontend_addon_name }}/.release-it.json
+++ b/templates/add-ons/frontend/{{ cookiecutter.__folder_name }}/packages/{{ cookiecutter.frontend_addon_name }}/.release-it.json
@@ -4,8 +4,8 @@
   },
   "hooks": {
     "after:bump": [
-      "pipx run towncrier build --draft --yes --version ${version} > .changelog.draft",
-      "pipx run towncrier build --yes --version ${version}",
+      "uvx towncrier build --draft --yes --version ${version} > .changelog.draft",
+      "uvx towncrier build --yes --version ${version}",
       "cp ../../README.md ./ && cp CHANGELOG.md ../../CHANGELOG.md",
       "python3 -c 'import json; data = json.load(open(\"../../package.json\")); data[\"version\"] = \"${version}\"; json.dump(data, open(\"../../package.json\", \"w\"), indent=2)'",
       "git add ../../CHANGELOG.md ../../package.json"
@@ -19,7 +19,7 @@
     "publish": true
   },
   "git": {
-    "changelog": "pipx run towncrier build --draft --yes --version 0.0.0",
+    "changelog": "uvx towncrier build --draft --yes --version 0.0.0",
     "requireUpstream": false,
     "requireCleanWorkingDir": false,
     "commitMessage": "Release ${version}",

--- a/templates/projects/plone7_nick_embedded/{{ cookiecutter.__folder_name }}/packages/{{ cookiecutter.frontend_addon_name }}/.release-it.json
+++ b/templates/projects/plone7_nick_embedded/{{ cookiecutter.__folder_name }}/packages/{{ cookiecutter.frontend_addon_name }}/.release-it.json
@@ -4,8 +4,8 @@
   },
   "hooks": {
     "after:bump": [
-      "pipx run towncrier build --draft --yes --version ${version} > .changelog.draft",
-      "pipx run towncrier build --yes --version ${version}",
+      "uvx towncrier build --draft --yes --version ${version} > .changelog.draft",
+      "uvx towncrier build --yes --version ${version}",
       "cp ../../README.md ./ && cp CHANGELOG.md ../../CHANGELOG.md",
       "python3 -c 'import json; data = json.load(open(\"../../package.json\")); data[\"version\"] = \"${version}\"; json.dump(data, open(\"../../package.json\", \"w\"), indent=2)'",
       "git add ../../CHANGELOG.md ../../package.json"
@@ -16,7 +16,7 @@
     "publish": false
   },
   "git": {
-    "changelog": "pipx run towncrier build --draft --yes --version 0.0.0",
+    "changelog": "uvx towncrier build --draft --yes --version 0.0.0",
     "requireUpstream": false,
     "requireCleanWorkingDir": false,
     "commitMessage": "Release ${version}",

--- a/uv.lock
+++ b/uv.lock
@@ -360,7 +360,7 @@ wheels = [
 
 [[package]]
 name = "cookiecutter"
-version = "2.6.0"
+version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arrow" },
@@ -372,14 +372,14 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/17/9f2cd228eb949a91915acd38d3eecdc9d8893dde353b603f0db7e9f6be55/cookiecutter-2.6.0.tar.gz", hash = "sha256:db21f8169ea4f4fdc2408d48ca44859349de2647fbe494a9d6c3edfc0542c21c", size = 158767, upload-time = "2024-02-21T18:02:41.949Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/03/f4c96d8fd4f5e8af0210bf896eb63927f35d3014a8e8f3bf9d2c43ad3332/cookiecutter-2.7.1.tar.gz", hash = "sha256:ca7bb7bc8c6ff441fbf53921b5537668000e38d56e28d763a1b73975c66c6138", size = 142854, upload-time = "2026-03-04T04:06:02.786Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/d9/0137658a353168ffa9d0fc14b812d3834772040858ddd1cb6eeaf09f7a44/cookiecutter-2.6.0-py3-none-any.whl", hash = "sha256:a54a8e37995e4ed963b3e82831072d1ad4b005af736bb17b99c2cbd9d41b6e2d", size = 39177, upload-time = "2024-02-21T18:02:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a9/8c855c14b401dc67d20739345295af5afce5e930a69600ab20f6cfa50b5c/cookiecutter-2.7.1-py3-none-any.whl", hash = "sha256:cee50defc1eaa7ad0071ee9b9893b746c1b3201b66bf4d3686d0f127c8ed6cf9", size = 41317, upload-time = "2026-03-04T04:06:01.221Z" },
 ]
 
 [[package]]
 name = "cookieplone"
-version = "2.0.0a2"
+version = "2.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cookiecutter" },
@@ -390,9 +390,9 @@ dependencies = [
     { name = "typer" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/26/f57a1ebae3882258911276a49ec929e146df0483c37724d873ac87f82151/cookieplone-2.0.0a2.tar.gz", hash = "sha256:b99b637c8fa727fa7a6672c6b6b47222c386be605747650f716c6ef8b6cb5ee6", size = 119808, upload-time = "2026-04-14T12:49:44.393Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/b0/8de1a9367d88ad0d617fa3490f9b8a7e03fe91d6305aeb1eab762ab8cef5/cookieplone-2.0.0b2.tar.gz", hash = "sha256:dab33d4a8538062cd6b0f7b020e24e99d141f6f5897915dc0bc56dd4e2c5af00", size = 153598, upload-time = "2026-06-05T14:33:25.366Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/ca/5e439d655316bb05ce1bd19c70ecaf77784e9245ea2ffdd6fec0fe70f72a/cookieplone-2.0.0a2-py3-none-any.whl", hash = "sha256:9112c35916f37ccafe68f062c6c345bace2f3145057139361f88a16414f229b3", size = 74513, upload-time = "2026-04-14T12:49:45.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5b/8c34e4c977bae8f1270debaca23a61976348dd75484750da5e95df149e0e/cookieplone-2.0.0b2-py3-none-any.whl", hash = "sha256:cafbf98cfdb5087edcd12e5f01e18189bed57499f6afd3f50d3d05556ba3703b", size = 92691, upload-time = "2026-06-05T14:33:24.003Z" },
 ]
 
 [[package]]
@@ -412,7 +412,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cookieplone", specifier = ">=2.0.0a2" },
+    { name = "cookieplone", specifier = ">=2.0.0b2" },
     { name = "gitpython", specifier = ">=3.1.43" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-jsonschema", specifier = ">=1.0.0" },
@@ -546,14 +546,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -923,11 +923,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -1616,15 +1616,15 @@ wheels = [
 
 [[package]]
 name = "tui-forms"
-version = "1.0.0a4"
+version = "1.0.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/43/8a95ae4b08d4109702df4cb29d51de6c623625ffb73fdbc93e0bdf693047/tui_forms-1.0.0a4.tar.gz", hash = "sha256:8c7cb0ceb5c60a3f83e693088be25de37f27cd930270f6a6a08936b7f302b0c8", size = 30320, upload-time = "2026-04-02T14:15:24.03Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/ad/cdda14f5f8fb14623581ea1b214ff02c0208488fa58c80d0187dde946372/tui_forms-1.0.0b1.tar.gz", hash = "sha256:7a9ec3ffaaef4009c5672b9bd7bcad7592c41540f0a17871f33d276f77a94ff6", size = 1165600, upload-time = "2026-05-29T15:17:49.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/b5/c7dc9108d172467d4f1f9590994a627a7b90f36f34485fb9d87e448951aa/tui_forms-1.0.0a4-py3-none-any.whl", hash = "sha256:a8274fbfd754fb18ba9d149a2f881447986aa4bc70ab558e7ef131b94ebbe7df", size = 41049, upload-time = "2026-04-02T14:15:25.369Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/45/64e7bc5a93094553e5bdf534ff2d832d2e6d216121d9ca53c651702c674c/tui_forms-1.0.0b1-py3-none-any.whl", hash = "sha256:a6e9b0ce30ebb794bd85da66eb92ff088afcfd5389bbfcec59e7edb13ef89d5d", size = 1629920, upload-time = "2026-05-29T15:17:46.973Z" },
 ]
 
 [[package]]
@@ -1648,17 +1648,17 @@ datetime = [
 
 [[package]]
 name = "typer"
-version = "0.24.1"
+version = "0.26.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/d3/90c1ee19209cb59f6ad185883fd4ccfcf72f8f0bfd549d5a8b70474611d0/typer-0.26.4.tar.gz", hash = "sha256:25b128964de66c5ea36d5ac82adc579e5e113509b17469edf9f5a4a1864ff2a9", size = 201191, upload-time = "2026-05-30T17:05:04.213Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6d/5a525c69df4a90892135e5d490b00e9e46402491f3416d4395fcb0d0201e/typer-0.26.4-py3-none-any.whl", hash = "sha256:11bfd7b43557137e373c2b10f6967a555f9678a61ed72c808968b011d95534d6", size = 122436, upload-time = "2026-05-30T17:05:05.812Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Two changes bundled together:

1. **Upgrade cookieplone to `2.0.0b2`** — bumps the `cookieplone` dependency from `2.0.0a2` to `2.0.0b2` in `pyproject.toml` and refreshes `uv.lock`.
2. **Use `uvx towncrier` instead of `pipx run towncrier` for release-it** — cherry-pick of #405 (fixes #404) from `main`, updating the `after:bump` and `git.changelog` hooks in both `.release-it.json` templates (`add-ons/frontend` and `projects/plone7_nick_embedded`).

## Why

- Keep the template collection aligned with the latest `cookieplone` beta.
- `uvx` is the standard tooling across the stack; the release-it hooks should match (avoids requiring `pipx` at release time).

## Notes

- The second commit is a cherry-pick from `main` (original author: @frapell).
- News fragments included: `news/+cookieplone.internal` and `news/404.bugfix`.

Closes #404