### PR TITLE
Bump cookieplone to 2.0.0b3 and adopt post-generation summary screen

### DIFF
--- a/cookieplone-config.json
+++ b/cookieplone-config.json
@@ -201,7 +201,16 @@
   },
   "config": {
     "renderer": "rich",
-    "min_version": "2.0.0a2",
+    "min_version": "2.0.0b3",
+    "summary": {
+      "enabled": true,
+      "message": "Now, code it, create a git repository, push to your organization.",
+      "thanks": "Sorry for the convenience,",
+      "signature": {
+        "text": "The Plone Community",
+        "url": "https://plone.org"
+      }
+    },
     "versions": {
       "backend_python": "3.13",
       "devops_cronjob_version": "1.14",

--- a/news/411.feature
+++ b/news/411.feature
@@ -1,0 +1,1 @@
+Bumped cookieplone to 2.0.0b3 and adopted the built-in post-generation summary screen, configurable via `config.summary` in `cookieplone-config.json`. @ericof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Collection of templates for Plone integrators to use through Cook
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "cookieplone>=2.0.0b2",
+    "cookieplone>=2.0.0b3",
     "gitpython>=3.1.43",
     "pytest>=8.3.5",
     "pytest-xdist>=3.5.0",

--- a/templates/add-ons/aurora_addon/hooks/post_gen_project.py
+++ b/templates/add-ons/aurora_addon/hooks/post_gen_project.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 from pathlib import Path
 
 from cookieplone import generator
-from cookieplone.utils import console
 from cookieplone.utils.subtemplates import run_subtemplates
 
 context: OrderedDict = {{cookiecutter}}
@@ -44,26 +43,6 @@ def main():
     # {{ cookiecutter.__cookieplone_subtemplates }}
     run_subtemplates(
         context, output_dir, handlers=SUBTEMPLATE_HANDLERS, global_versions=versions
-    )
-
-    msg = """
-        [bold blue]{{ cookiecutter.frontend_addon_name }}[/bold blue]
-
-        Now, enter the generated directory and finish the install:
-
-        cd {{ cookiecutter.frontend_addon_name }}
-        make install
-
-        start coding, and push to your organization.
-
-        Sorry for the convenience,
-        The Plone Community.
-    """
-    console.panel(
-        title=":tada: New addon was generated :tada:",
-        subtitle="",
-        msg=msg,
-        url="https://plone.org/",
     )
 
 

--- a/templates/add-ons/backend/hooks/post_gen_project.py
+++ b/templates/add-ons/backend/hooks/post_gen_project.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from cookieplone import generator
 from cookieplone.settings import QUIET_MODE_VAR
-from cookieplone.utils import console, files, plone, post_gen
+from cookieplone.utils import plone, post_gen
 from cookieplone.utils.subtemplates import run_subtemplates
 
 context: OrderedDict = {{cookiecutter}}
@@ -156,18 +156,6 @@ def main():
     # {{ cookiecutter.__cookieplone_subtemplates }}
     run_subtemplates(
         context, output_dir, handlers=SUBTEMPLATE_HANDLERS, global_versions=versions
-    )
-
-    msg = """
-        [bold blue]{{ cookiecutter.title }}[/bold blue]
-
-        Now, enter the repository, start coding, and push to your organization.
-
-        Sorry for the convenience,
-        The Plone Community.
-    """
-    console.panel(
-        title="New addon was generated", subtitle="", msg=msg, url="https://plone.org/"
     )
 
 

--- a/templates/add-ons/frontend/hooks/post_gen_project.py
+++ b/templates/add-ons/frontend/hooks/post_gen_project.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 from pathlib import Path
 
 from cookieplone import generator
-from cookieplone.utils import console, files
 from cookieplone.utils.subtemplates import run_subtemplates
 
 context: OrderedDict = {{cookiecutter}}
@@ -99,26 +98,6 @@ def main():
     )
 
     remove_conditional_files(context, output_dir)
-
-    msg = """
-        [bold blue]{{ cookiecutter.frontend_addon_name }}[/bold blue]
-
-        Now, enter the generated directory and finish the install:
-
-        cd {{ cookiecutter.frontend_addon_name }}
-        make install
-
-        start coding, and push to your organization.
-
-        Sorry for the convenience,
-        The Plone Community.
-    """
-    console.panel(
-        title=":tada: New addon was generated :tada:",
-        subtitle="",
-        msg=msg,
-        url="https://plone.org/",
-    )
 
 
 if __name__ == "__main__":

--- a/templates/add-ons/monorepo/hooks/post_gen_project.py
+++ b/templates/add-ons/monorepo/hooks/post_gen_project.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from binaryornot.check import is_binary
 from cookieplone import generator
-from cookieplone.utils import console, plone, post_gen
+from cookieplone.utils import plone, post_gen
 from cookieplone.utils.subtemplates import run_subtemplates
 
 context: OrderedDict = {{cookiecutter}}
@@ -252,21 +252,6 @@ def main():
 
     # Action handlers
     post_gen.run_post_gen_actions(context, output_dir, action_handlers(context))
-
-    msg = """
-        [bold blue]{{ cookiecutter.title }}[/bold blue]
-
-        Now, code it, create a git repository, push to your organization.
-
-        Sorry for the convenience,
-        The Plone Community.
-    """
-    console.panel(
-        title="New add-on was generated",
-        subtitle="",
-        msg=msg,
-        url="https://plone.org/",
-    )
 
 
 if __name__ == "__main__":

--- a/templates/devops/ansible/hooks/post_gen_project.py
+++ b/templates/devops/ansible/hooks/post_gen_project.py
@@ -45,22 +45,6 @@ def main():
     # Action handlers
     post_gen.run_post_gen_actions(context, output_dir, action_handlers(context))
 
-    msg = """
-        [bold blue]{{ cookiecutter.title }}[/bold blue]
-
-        Now, enter the {{ cookiecutter.folder_name }} folder, start using your
-        playbooks.
-
-        Sorry for the convenience,
-        The Plone Community.
-    """
-    console.panel(
-        title="New Ansible setup created",
-        subtitle="",
-        msg=msg,
-        url="https://plone.org/",
-    )
-
 
 if __name__ == "__main__":
     main()

--- a/templates/docs/starter/hooks/post_gen_project.py
+++ b/templates/docs/starter/hooks/post_gen_project.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from pathlib import Path
 
-from cookieplone.utils import console, post_gen
+from cookieplone.utils import post_gen
 
 context: OrderedDict = {{cookiecutter}}
 versions: dict | OrderedDict = {{versions}}
@@ -32,21 +32,6 @@ def main():
 
     # Action handlers
     post_gen.run_post_gen_actions(context, output_dir, action_handlers(context))
-
-    msg = """
-        [bold blue]{{ cookiecutter.title }}[/bold blue]
-
-        Now, enter the docs folder, start documenting the code, and push to your organization.
-
-        Sorry for the convenience,
-        The Plone Community.
-    """
-    console.panel(
-        title="New documentation scaffold was generated",
-        subtitle="",
-        msg=msg,
-        url="https://plone.org/",
-    )
 
 
 if __name__ == "__main__":

--- a/templates/projects/classic/hooks/post_gen_project.py
+++ b/templates/projects/classic/hooks/post_gen_project.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from pathlib import Path
 
 from cookieplone import generator
-from cookieplone.utils import console, plone, post_gen
+from cookieplone.utils import plone, post_gen
 from cookieplone.utils.subtemplates import run_subtemplates
 
 context: OrderedDict = {{cookiecutter}}
@@ -240,21 +240,6 @@ def main():
 
     # Action handlers
     post_gen.run_post_gen_actions(context, output_dir, action_handlers(context))
-
-    msg = """
-        [bold blue]{{ cookiecutter.title }}[/bold blue]
-
-        Now, code it, create a git repository, push to your organization.
-
-        Sorry for the convenience,
-        The Plone Community.
-    """
-    console.panel(
-        title="New project was generated",
-        subtitle="",
-        msg=msg,
-        url="https://plone.org/",
-    )
 
 
 if __name__ == "__main__":

--- a/templates/projects/monorepo/hooks/post_gen_project.py
+++ b/templates/projects/monorepo/hooks/post_gen_project.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from binaryornot.check import is_binary
 from cookieplone import generator
-from cookieplone.utils import console, npm, plone, post_gen
+from cookieplone.utils import npm, plone, post_gen
 from cookieplone.utils.subtemplates import run_subtemplates
 
 context: OrderedDict = {{cookiecutter}}
@@ -307,21 +307,6 @@ def main():
 
     # Action handlers
     post_gen.run_post_gen_actions(context, output_dir, action_handlers(context))
-
-    msg = """
-        [bold blue]{{ cookiecutter.title }}[/bold blue]
-
-        Now, code it, create a git repository, push to your organization.
-
-        Sorry for the convenience,
-        The Plone Community.
-    """
-    console.panel(
-        title="New project was generated",
-        subtitle="",
-        msg=msg,
-        url="https://plone.org/",
-    )
 
 
 if __name__ == "__main__":

--- a/templates/sub/frontend_project/hooks/post_gen_project.py
+++ b/templates/sub/frontend_project/hooks/post_gen_project.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from pathlib import Path
 
 from cookieplone import generator
-from cookieplone.utils import console, files
+from cookieplone.utils import files
 
 context: OrderedDict = {{cookiecutter}}
 versions: dict | OrderedDict = {{versions}}
@@ -54,20 +54,6 @@ def main():
     generate_addon(context, output_dir)
     # Cleanup
     cleanup(context, output_dir)
-    msg = """
-        [bold blue]{{ cookiecutter.title }}[/bold blue]
-
-        Now, code it, create a git repository, push to your organization.
-
-        Sorry for the convenience,
-        The Plone Community.
-    """
-    console.panel(
-        title="New project was generated",
-        subtitle="",
-        msg=msg,
-        url="https://plone.org/",
-    )
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -379,7 +379,7 @@ wheels = [
 
 [[package]]
 name = "cookieplone"
-version = "2.0.0b2"
+version = "2.0.0b3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cookiecutter" },
@@ -390,9 +390,9 @@ dependencies = [
     { name = "typer" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/b0/8de1a9367d88ad0d617fa3490f9b8a7e03fe91d6305aeb1eab762ab8cef5/cookieplone-2.0.0b2.tar.gz", hash = "sha256:dab33d4a8538062cd6b0f7b020e24e99d141f6f5897915dc0bc56dd4e2c5af00", size = 153598, upload-time = "2026-06-05T14:33:25.366Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/06/dbc434002628fa51359d8f4bd9e96dccd2248765d217f4cd59992297aafa/cookieplone-2.0.0b3.tar.gz", hash = "sha256:0120306ac57261921d2e63f6b610385ee0488a104eb4fd27810f1f218dae0039", size = 158472, upload-time = "2026-06-07T18:36:49.366Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/5b/8c34e4c977bae8f1270debaca23a61976348dd75484750da5e95df149e0e/cookieplone-2.0.0b2-py3-none-any.whl", hash = "sha256:cafbf98cfdb5087edcd12e5f01e18189bed57499f6afd3f50d3d05556ba3703b", size = 92691, upload-time = "2026-06-05T14:33:24.003Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f7/b696c5f93421211449843d96b9426396594b707d2b12095a8b21138e23ca/cookieplone-2.0.0b3-py3-none-any.whl", hash = "sha256:4a8077244397c84f1d542a6679df838fe8864ccffd34e35f972a0124729eb2e6", size = 94624, upload-time = "2026-06-07T18:36:50.369Z" },
 ]
 
 [[package]]
@@ -412,7 +412,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cookieplone", specifier = ">=2.0.0b2" },
+    { name = "cookieplone", specifier = ">=2.0.0b3" },
     { name = "gitpython", specifier = ">=3.1.43" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-jsonschema", specifier = ">=1.0.0" },
@@ -1616,15 +1616,15 @@ wheels = [
 
 [[package]]
 name = "tui-forms"
-version = "1.0.0b1"
+version = "1.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/ad/cdda14f5f8fb14623581ea1b214ff02c0208488fa58c80d0187dde946372/tui_forms-1.0.0b1.tar.gz", hash = "sha256:7a9ec3ffaaef4009c5672b9bd7bcad7592c41540f0a17871f33d276f77a94ff6", size = 1165600, upload-time = "2026-05-29T15:17:49.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/f4/d322a781d50373ba3ac72a251a1c5bfd75bcac1b8cf532ca9754804df3ee/tui_forms-1.0.0b2.tar.gz", hash = "sha256:05603a5c528eba9d0b10843175fdc69e0316ff5955bd89d9c7d3b1e72ba17aee", size = 1165541, upload-time = "2026-06-05T19:52:29.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/45/64e7bc5a93094553e5bdf534ff2d832d2e6d216121d9ca53c651702c674c/tui_forms-1.0.0b1-py3-none-any.whl", hash = "sha256:a6e9b0ce30ebb794bd85da66eb92ff088afcfd5389bbfcec59e7edb13ef89d5d", size = 1629920, upload-time = "2026-05-29T15:17:46.973Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6d/f84e2ab64417ec817da909c708d2ad88115b01fac59006f0cafe6f86d9ab/tui_forms-1.0.0b2-py3-none-any.whl", hash = "sha256:0ce11ede01bc4c6fc541fe7ab4eb10cdc7e3d722bb6c10af742ed3169854b4de", size = 1629936, upload-time = "2026-06-05T19:52:31.304Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `cookieplone` to `2.0.0b3` and adopts the built-in post-generation summary screen now provided upstream ([plone/cookieplone#204](https://github.com/plone/cookieplone/issues/204)).

cookieplone now renders the summary panel automatically after generation, so templates no longer need to reimplement the `console.panel(...)` block in each `post_hook` script. The screen is configured through `config.summary` in `cookieplone-config.json` (`enabled`, `message`, `thanks`, `signature.{text,url}`).

## Changes

- Bump `cookieplone>=2.0.0b2` → `cookieplone>=2.0.0b3` (`pyproject.toml`, `uv.lock`)
- Bump `config.min_version` → `2.0.0b3` and add the `config.summary` block in `cookieplone-config.json`
- Remove the redundant summary-panel code from template `post_gen` hooks, pruning now-unused imports
- Add `news/411.feature`

## Notes

- The `plone7_nick_embedded` hook keeps its bespoke panel — it carries template-specific instructions, and will likely drive support for per-template summary overrides later.
- The `config.summary` values currently mirror cookieplone's defaults; only `enabled: true` is strictly required, but the explicit keys document the available override points.

## Testing

- `make test` — all 1330 tests pass

Closes #411