### PR TITLE
Fix CI workflow argument source for node-version

### DIFF
--- a/news/413.bugfix
+++ b/news/413.bugfix
@@ -1,0 +1,1 @@
+Fix CI workflow argument source for node-version. @ksuess

--- a/templates/ci/gh_monorepo_addon/{{ cookiecutter.__folder_name }}/workflows/frontend.yml
+++ b/templates/ci/gh_monorepo_addon/{{ cookiecutter.__folder_name }}/workflows/frontend.yml
@@ -57,7 +57,7 @@ jobs:
       - unit
       - i18n
     with:
-      node-version: {{ "${{ needs.config.outputs.node-version }}" }}
+      node-version: {{ "${{ inputs.node-version }}" }}
       working-directory: {{ "${{ inputs.working-directory }}" }}
       deploy: {{ "${{ inputs.storybook-deploy }}" }}
 

--- a/templates/ci/gh_project/{{ cookiecutter.__folder_name }}/workflows/frontend.yml
+++ b/templates/ci/gh_project/{{ cookiecutter.__folder_name }}/workflows/frontend.yml
@@ -57,7 +57,7 @@ jobs:
       - unit
       - i18n
     with:
-      node-version: {{ "${{ needs.config.outputs.node-version }}" }}
+      node-version: {{ "${{ inputs.node-version }}" }}
       working-directory: {{ "${{ inputs.working-directory }}" }}
       deploy: {{ "${{ inputs.storybook-deploy }}" }}
 


### PR DESCRIPTION
just a fix for a copy paste error.
config values of the main calling workflow are forwarded and then accessible via input values.