### PR TITLE
Fix make format for generated paths with spaces

### DIFF
--- a/news/+quote-make-format-paths.bugfix
+++ b/news/+quote-make-format-paths.bugfix
@@ -1,0 +1,1 @@
+Fixed post-generation backend formatting commands so generated projects inside directories with spaces in their path can run the make format step without the shell splitting the path.

--- a/templates/add-ons/monorepo/hooks/post_gen_project.py
+++ b/templates/add-ons/monorepo/hooks/post_gen_project.py
@@ -239,8 +239,9 @@ def main():
     if backend_format:
         backend_folder = output_dir / "backend"
         # Run make format in the backend folder
-        cmd = f"make -C {backend_folder} format"
-        subprocess.call(cmd, shell=True)  # noQA: S602
+        subprocess.call(  # noqa: S603, S607
+            ["make", "-C", str(backend_folder), "format"]
+        )
 
     # Cleanup / Git
     actions = [

--- a/templates/projects/classic/hooks/post_gen_project.py
+++ b/templates/projects/classic/hooks/post_gen_project.py
@@ -219,8 +219,9 @@ def main():
     if backend_format:
         backend_folder = output_dir / "backend"
         # Run make format in the backend folder
-        cmd = f"make -C {backend_folder} format"
-        subprocess.call(cmd, shell=True)  # noQA: S602
+        subprocess.call(  # noqa: S603, S607
+            ["make", "-C", str(backend_folder), "format"]
+        )
 
     # Cleanup / Git
     actions = [

--- a/templates/projects/monorepo/hooks/post_gen_project.py
+++ b/templates/projects/monorepo/hooks/post_gen_project.py
@@ -282,8 +282,9 @@ def main():
     if backend_format:
         backend_folder = output_dir / "backend"
         # Run make format in the backend folder
-        cmd = f"make -C {backend_folder} format"
-        subprocess.call(cmd, shell=True)  # noQA: S602
+        subprocess.call(  # noqa: S603, S607
+            ["make", "-C", str(backend_folder), "format"]
+        )
 
     # Cleanup / Git
     actions = [


### PR DESCRIPTION
## Summary
- run post-generation `make format` calls with an argument list instead of a shell string
- prevent generated backend paths containing spaces from being split by the shell
- update the classic, project monorepo, and add-on monorepo templates

References plone/cookieplone#208.

## Tests
- `git diff --check`
- `python3` proof with `make -C` against a backend path containing spaces
- `uv run pytest tests/templates/projects/classic -q`
- `PATH="/tmp/cookieplone-fake-node:$PATH" uv run pytest tests/templates/projects/monorepo/test_project_variables.py tests/templates/add-ons/monorepo/test_monorepo_variables.py -q`

Note: the full monorepo generation suite requires a supported Node version. My local Node is v26, which the template sanity check rejects, so I ran the focused monorepo variable tests with a fake Node v22 version probe.