### PR TITLE
Remove container_registry_prefix_separator from __container_image_prefix

### DIFF
--- a/news/421.bugfix
+++ b/news/421.bugfix
@@ -1,0 +1,1 @@
+Removed the trailing registry separator from `__container_image_prefix`, fixing the duplicated dash it produced in container image names consumed by the plone/meta GitHub Actions. The separator is now applied only where needed (Makefiles, stack files, and docs). @ericof

--- a/templates/add-ons/monorepo/cookieplone.json
+++ b/templates/add-ons/monorepo/cookieplone.json
@@ -240,7 +240,7 @@
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/add-ons/monorepo/{{ cookiecutter.__folder_name }}/Makefile
+++ b/templates/add-ons/monorepo/{{ cookiecutter.__folder_name }}/Makefile
@@ -17,6 +17,8 @@ PROJECT_NAME=$(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.name')
 STACK_NAME=${PROJECT_NAME}
 
 IMAGE_NAME_PREFIX := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.container_images_prefix')
+IMAGE_NAME_SEPARATOR := {{ cookiecutter.__container_registry_prefix_separator }}
+IMAGE_NAME_PREFIX_WITH_SEPARATOR := $(IMAGE_NAME_PREFIX)$(IMAGE_NAME_SEPARATOR)
 
 # Environment variables to be exported
 export VOLTO_VERSION := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.frontend.volto_version')
@@ -46,6 +48,7 @@ debug-settings:  ## Debug settings
 	@echo "VOLTO_VERSION: $(VOLTO_VERSION)"
 	@echo "PLONE_VERSION: $(PLONE_VERSION)"
 	@echo "IMAGE_NAME_PREFIX: $(IMAGE_NAME_PREFIX)"
+	@echo "IMAGE_NAME_PREFIX_WITH_SEPARATOR: $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)"
 
 ###########################################
 # Frontend
@@ -207,12 +210,12 @@ acceptance-test:
 .PHONY: acceptance-frontend-image-build
 acceptance-frontend-image-build:
 	@echo "Build acceptance frontend image"
-	@docker build frontend -t $(IMAGE_NAME_PREFIX)frontend:acceptance -f frontend/Dockerfile --build-arg VOLTO_VERSION=$(VOLTO_VERSION)
+	@docker build frontend -t $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)frontend:acceptance -f frontend/Dockerfile --build-arg VOLTO_VERSION=$(VOLTO_VERSION)
 
 .PHONY: acceptance-backend-image-build
 acceptance-backend-image-build:
 	@echo "Build acceptance backend image"
-	@docker build backend -t $(IMAGE_NAME_PREFIX)backend:acceptance -f backend/Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
+	@docker build backend -t $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend:acceptance -f backend/Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
 
 .PHONY: acceptance-images-build
 acceptance-images-build: ## Build Acceptance frontend/backend images
@@ -222,12 +225,12 @@ acceptance-images-build: ## Build Acceptance frontend/backend images
 .PHONY: acceptance-frontend-container-start
 acceptance-frontend-container-start:
 	@echo "Start acceptance frontend"
-	@docker run --rm -p 3000:3000 --name $(IMAGE_NAME_PREFIX)frontend-acceptance --link $(IMAGE_NAME_PREFIX)backend-acceptance:backend -e RAZZLE_API_PATH=http://localhost:55001/plone -e RAZZLE_INTERNAL_API_PATH=http://backend:55001/plone -d $(IMAGE_NAME_PREFIX)frontend:acceptance
+	@docker run --rm -p 3000:3000 --name $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)frontend-acceptance --link $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend-acceptance:backend -e RAZZLE_API_PATH=http://localhost:55001/plone -e RAZZLE_INTERNAL_API_PATH=http://backend:55001/plone -d $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)frontend:acceptance
 
 .PHONY: acceptance-backend-container-start
 acceptance-backend-container-start:
 	@echo "Start acceptance backend"
-	@docker run --rm -p 55001:55001 --name $(IMAGE_NAME_PREFIX)backend-acceptance -d $(IMAGE_NAME_PREFIX)backend:acceptance
+	@docker run --rm -p 55001:55001 --name $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend-acceptance -d $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend:acceptance
 
 .PHONY: acceptance-containers-start
 acceptance-containers-start: ## Start Acceptance containers
@@ -237,8 +240,8 @@ acceptance-containers-start: ## Start Acceptance containers
 .PHONY: acceptance-containers-stop
 acceptance-containers-stop: ## Stop Acceptance containers
 	@echo "Stop acceptance containers"
-	@docker stop $(IMAGE_NAME_PREFIX)frontend-acceptance
-	@docker stop $(IMAGE_NAME_PREFIX)backend-acceptance
+	@docker stop $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)frontend-acceptance
+	@docker stop $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend-acceptance
 
 .PHONY: ci-acceptance-test
 ci-acceptance-test:

--- a/templates/projects/classic/cookieplone.json
+++ b/templates/projects/classic/cookieplone.json
@@ -230,7 +230,7 @@
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/projects/classic/{{ cookiecutter.__folder_name }}/devops/stacks/{{ cookiecutter.hostname }}.yml
+++ b/templates/projects/classic/{{ cookiecutter.__folder_name }}/devops/stacks/{{ cookiecutter.hostname }}.yml
@@ -99,7 +99,7 @@ services:
         order: start-first
 
   varnish:
-    image: {{ cookiecutter.__container_image_prefix }}varnish:${STACK_PARAM:-latest}
+    image: {{ cookiecutter.__container_image_prefix }}{{ cookiecutter.__container_registry_prefix_separator }}varnish:${STACK_PARAM:-latest}
     command:
       - '-p'
       - 'nuke_limit=2000'
@@ -134,7 +134,7 @@ services:
 {%- endif %}
 
   backend:
-    image: {{ cookiecutter.__container_image_prefix }}backend:${STACK_PARAM:-latest}
+    image: {{ cookiecutter.__container_image_prefix }}{{ cookiecutter.__container_registry_prefix_separator }}backend:${STACK_PARAM:-latest}
 {%- if cookiecutter.devops_storage == 'relstorage' %}
     environment:
       RELSTORAGE_DSN: "dbname='${DB_NAME:-plone}' user='${DB_USER:-plone}' host='${DB_HOST:-db}' password='${DB_PASSWORD:-{{ cookiecutter.__devops_db_password }}}' port='${DB_PORT:-5432}'"

--- a/templates/projects/monorepo/cookieplone.json
+++ b/templates/projects/monorepo/cookieplone.json
@@ -324,7 +324,7 @@
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/devops/README-GHA.md
+++ b/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/devops/README-GHA.md
@@ -51,7 +51,7 @@ Ensure that both Backend and Frontend tests have been successfully executed:
 - [Backend Tests Workflow]({{ cookiecutter.__repository_url }}/actions/workflows/backend.yml)
 - [Frontend Tests Workflow]({{ cookiecutter.__repository_url }}/actions/workflows/frontend.yml)
 
-Upon successful completion of the tests, Docker images for the Backend (`{{ cookiecutter.__container_image_prefix }}backend`) and Frontend (`{{ cookiecutter.__container_image_prefix }}frontend`) will be available.
+Upon successful completion of the tests, Docker images for the Backend (`{{ cookiecutter.__container_image_prefix }}{{ cookiecutter.__container_registry_prefix_separator }}backend`) and Frontend (`{{ cookiecutter.__container_image_prefix }}{{ cookiecutter.__container_registry_prefix_separator }}frontend`) will be available.
 
 ### Initiating Manual Deployment
 

--- a/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/devops/stacks/{{ cookiecutter.hostname }}.yml
+++ b/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/devops/stacks/{{ cookiecutter.hostname }}.yml
@@ -99,7 +99,7 @@ services:
         order: start-first
 
   varnish:
-    image: {{ cookiecutter.__container_image_prefix }}varnish:${STACK_PARAM:-latest}
+    image: {{ cookiecutter.__container_image_prefix }}{{ cookiecutter.__container_registry_prefix_separator }}varnish:${STACK_PARAM:-latest}
     command:
       - '-p'
       - 'nuke_limit=2000'
@@ -135,7 +135,7 @@ services:
 {%- endif %}
 
   frontend:
-    image: {{ cookiecutter.__container_image_prefix }}frontend:${STACK_PARAM:-latest}
+    image: {{ cookiecutter.__container_image_prefix }}{{ cookiecutter.__container_registry_prefix_separator }}frontend:${STACK_PARAM:-latest}
     environment:
       RAZZLE_INTERNAL_API_PATH: http://backend:8080/Plone
       RAZZLE_API_PATH: https://{{ cookiecutter.hostname }}
@@ -172,7 +172,7 @@ services:
 {%- endif %}
 
   backend:
-    image: {{ cookiecutter.__container_image_prefix }}backend:${STACK_PARAM:-latest}
+    image: {{ cookiecutter.__container_image_prefix }}{{ cookiecutter.__container_registry_prefix_separator }}backend:${STACK_PARAM:-latest}
 {%- if cookiecutter.devops_storage == 'relstorage' %}
     environment:
       RELSTORAGE_DSN: "dbname='${DB_NAME:-plone}' user='${DB_USER:-plone}' host='${DB_HOST:-db}' password='${DB_PASSWORD:-{{ cookiecutter.__devops_db_password }}}' port='${DB_PORT:-5432}'"

--- a/templates/sub/addon_settings/cookieplone.json
+++ b/templates/sub/addon_settings/cookieplone.json
@@ -176,7 +176,7 @@
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/sub/addon_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/templates/sub/addon_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -25,8 +25,11 @@ endif
 
 REPOSITORY_SETTINGS := $(shell uvx repoplone settings dump)
 IMAGE_NAME_PREFIX := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.container_images_prefix')
+IMAGE_NAME_SEPARATOR := {{ cookiecutter.__container_registry_prefix_separator }}
+IMAGE_NAME_PREFIX_WITH_SEPARATOR := $(IMAGE_NAME_PREFIX)$(IMAGE_NAME_SEPARATOR)
+
 IMAGE_TAG=latest
-IMAGE_NAME=$(IMAGE_NAME_PREFIX)backend:$(IMAGE_TAG)
+IMAGE_NAME=$(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend:$(IMAGE_TAG)
 
 PLONE_SITE_ID=Plone
 BACKEND_FOLDER=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
@@ -64,6 +67,7 @@ debug-settings:  ## Debug settings
 	@echo "PLONE_VERSION: $(PLONE_VERSION)"
 	@echo "PACKAGE_NAME: $(PACKAGE_NAME)"
 	@echo "EXAMPLE_CONTENT_FOLDER: $(EXAMPLE_CONTENT_FOLDER)"
+	@echo "IMAGE_NAME_PREFIX_WITH_SEPARATOR: $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)"
 	@echo "IMAGE_NAME: $(IMAGE_NAME)"
 
 
@@ -164,7 +168,7 @@ acceptance-backend-start: ## Start backend acceptance server
 
 .PHONY: acceptance-image-build
 acceptance-image-build:  ## Build Docker Images
-	@docker build . -t $(IMAGE_NAME_PREFIX)backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
+	@docker build . -t $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
 
 ## Add bobtemplates features (check bobtemplates.plone's documentation to get the list of available features)
 add: $(VENV_FOLDER)

--- a/templates/sub/addon_settings/{{ cookiecutter.__folder_name }}/frontend/Makefile
+++ b/templates/sub/addon_settings/{{ cookiecutter.__folder_name }}/frontend/Makefile
@@ -25,9 +25,11 @@ DOCKER_IMAGE=plone/server-dev:${PLONE_VERSION}
 DOCKER_IMAGE_ACCEPTANCE=plone/server-acceptance:${PLONE_VERSION}
 
 ADDON_NAME := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.frontend.name')
-IMAGE_NAME_PREFIX := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.container_images_prefix')
+IMAGE_NAME_SEPARATOR := {{ cookiecutter.__container_registry_prefix_separator }}
+IMAGE_NAME_PREFIX_WITH_SEPARATOR := $(IMAGE_NAME_PREFIX)$(IMAGE_NAME_SEPARATOR)
+
 IMAGE_TAG=latest
-IMAGE_NAME=$(IMAGE_NAME_PREFIX)frontend:$(IMAGE_TAG)
+IMAGE_NAME=$(IMAGE_NAME_PREFIX_WITH_SEPARATOR)frontend:$(IMAGE_TAG)
 
 # Environment variables to be exported
 export VOLTO_VERSION := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.frontend.volto_version')

--- a/templates/sub/classic_project_settings/cookieplone.json
+++ b/templates/sub/classic_project_settings/cookieplone.json
@@ -139,7 +139,7 @@
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/sub/classic_project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/templates/sub/classic_project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -15,7 +15,11 @@ GREEN=`tput setaf 2`
 RESET=`tput sgr0`
 YELLOW=`tput setaf 3`
 
-IMAGE_NAME_PREFIX={{ cookiecutter.__container_image_prefix }}
+IMAGE_NAME_PREFIX := {{ cookiecutter.__container_image_prefix }}
+IMAGE_NAME_SEPARATOR := {{ cookiecutter.__container_registry_prefix_separator }}
+IMAGE_NAME_PREFIX_WITH_SEPARATOR := $(IMAGE_NAME_PREFIX)$(IMAGE_NAME_SEPARATOR)
+
+
 IMAGE_TAG=latest
 
 # Python checks
@@ -139,7 +143,7 @@ test-coverage: $(VENV_FOLDER) ## run tests with coverage
 # Build Docker images
 .PHONY: build-image
 build-image:  ## Build Docker Images
-	@docker build . -t $(IMAGE_NAME_PREFIX)backend:$(IMAGE_TAG) -f Dockerfile --build-arg PLONE_VERSION=$(PLONE_VERSION)
+	@docker build . -t $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend:$(IMAGE_TAG) -f Dockerfile --build-arg PLONE_VERSION=$(PLONE_VERSION)
 
 # Acceptance tests
 .PHONY: acceptance-backend-start
@@ -148,7 +152,7 @@ acceptance-backend-start: ## Start backend acceptance server
 
 .PHONY: acceptance-image-build
 acceptance-image-build:  ## Build Docker Images
-	@docker build . -t $(IMAGE_NAME_PREFIX)backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
+	@docker build . -t $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION)
 
 ## Add bobtemplates features (check bobtemplates.plone's documentation to get the list of available features)
 add: $(VENV_FOLDER)

--- a/templates/sub/project_settings/cookieplone.json
+++ b/templates/sub/project_settings/cookieplone.json
@@ -174,7 +174,7 @@
             "__container_image_prefix": {
                 "type": "string",
                 "title": "__container_image_prefix",
-                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}{{ cookiecutter.__container_registry_prefix_separator }}",
+                "default": "{{ cookiecutter.__container_registry_prefix }}{{ cookiecutter.github_organization }}/{{ cookiecutter.project_slug }}",
                 "validator": "",
                 "format": "computed"
             },

--- a/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
+++ b/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/backend/Makefile
@@ -25,8 +25,11 @@ endif
 
 REPOSITORY_SETTINGS := $(shell uvx repoplone settings dump)
 IMAGE_NAME_PREFIX := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.container_images_prefix')
+IMAGE_NAME_SEPARATOR := {{ cookiecutter.__container_registry_prefix_separator }}
+IMAGE_NAME_PREFIX_WITH_SEPARATOR := $(IMAGE_NAME_PREFIX)$(IMAGE_NAME_SEPARATOR)
+
 IMAGE_TAG=latest
-IMAGE_NAME=$(IMAGE_NAME_PREFIX)backend:$(IMAGE_TAG)
+IMAGE_NAME=$(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend:$(IMAGE_TAG)
 
 PLONE_SITE_ID=Plone
 BACKEND_FOLDER=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
@@ -174,7 +177,7 @@ acceptance-backend-start: ## Start backend acceptance server
 
 .PHONY: acceptance-image-build
 acceptance-image-build:  ## Build Docker Images
-	@docker build . -t $(IMAGE_NAME_PREFIX)backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION) --build-arg PYTHON_VERSION=$(PYTHON_VERSION)
+	@docker build . -t $(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg PLONE_VERSION=$(PLONE_VERSION) --build-arg PYTHON_VERSION=$(PYTHON_VERSION)
 
 ############################################
 # Plone CLI

--- a/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/frontend/Makefile
+++ b/templates/sub/project_settings/{{ cookiecutter.__folder_name }}/frontend/Makefile
@@ -29,7 +29,10 @@ DOCKER_IMAGE_ACCEPTANCE=plone/server-acceptance:${PLONE_VERSION}
 
 ADDON_NAME := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.frontend.name')
 IMAGE_NAME_PREFIX := $(shell echo '$(REPOSITORY_SETTINGS)' | jq -r '.container_images_prefix')
-IMAGE_NAME=$(IMAGE_NAME_PREFIX)frontend
+IMAGE_NAME_SEPARATOR := {{ cookiecutter.__container_registry_prefix_separator }}
+IMAGE_NAME_PREFIX_WITH_SEPARATOR := $(IMAGE_NAME_PREFIX)$(IMAGE_NAME_SEPARATOR)
+
+IMAGE_NAME=$(IMAGE_NAME_PREFIX_WITH_SEPARATOR)frontend
 IMAGE_TAG=latest
 
 

--- a/tests/templates/add-ons/monorepo/test_monorepo_images.py
+++ b/tests/templates/add-ons/monorepo/test_monorepo_images.py
@@ -4,9 +4,9 @@ import pytest
 @pytest.mark.parametrize(
     "registry,expected_prefix,expected_separator",
     [
-        ("github", "ghcr.io/collective/collective-addon-", "-"),
-        ("gitlab", "registry.gitlab.com/collective/collective-addon/", "/"),
-        ("docker_hub", "collective/collective-addon-", "-"),
+        ("github", "ghcr.io/collective/collective-addon", "-"),
+        ("gitlab", "registry.gitlab.com/collective/collective-addon", "/"),
+        ("docker_hub", "collective/collective-addon", "-"),
     ],
 )
 def test_monorepo_addon_image_prefix_registry(
@@ -30,5 +30,9 @@ def test_monorepo_addon_image_prefix_registry(
     # Check root Makefile
     root_makefile = result.project_path / "Makefile"
     # In monorepo addon, acceptance images use IMAGE_NAME_PREFIX
-    assert "$(IMAGE_NAME_PREFIX)frontend:acceptance" in root_makefile.read_text()
+    assert (
+        "$(IMAGE_NAME_PREFIX_WITH_SEPARATOR)frontend:acceptance"
+        in root_makefile.read_text()
+    )
+    assert "$(IMAGE_NAME_PREFIX)frontend:acceptance" not in root_makefile.read_text()
     assert "$(IMAGE_NAME_PREFIX)-frontend:acceptance" not in root_makefile.read_text()

--- a/tests/templates/ci/gh_backend_addon/test_gh_backend_addon_cutter.py
+++ b/tests/templates/ci/gh_backend_addon/test_gh_backend_addon_cutter.py
@@ -52,3 +52,22 @@ def test_created_files(cutter_result, file_path: str):
     path = (cutter_result.project_path / file_path).resolve()
     assert path.exists()
     assert path.is_file()
+
+
+@pytest.mark.parametrize(
+    "file_path,text,expected",
+    [
+        ("workflows/changelog.yml", "uvx towncrier check --dir .", True),
+        ("workflows/changelog.yml", "pipx", False),
+        (
+            "workflows/config.yml",
+            "echo 'plone-version: ${{ steps.vars.outputs.plone-version }}",
+            True,
+        ),
+        ("workflows/main.yml", "uses: ./.github/workflows/config.yml", True),
+    ],
+)
+def test_content(cutter_result, file_path: str, text: str, expected: bool):
+    path = (cutter_result.project_path / file_path).resolve()
+    contents = path.read_text()
+    assert (text in contents) is expected

--- a/tests/templates/ci/gh_classic_project/test_gh_classic_project_cutter.py
+++ b/tests/templates/ci/gh_classic_project/test_gh_classic_project_cutter.py
@@ -54,3 +54,31 @@ def test_created_files(cutter_result, file_path: str):
     path = (cutter_result.project_path / file_path).resolve()
     assert path.exists()
     assert path.is_file()
+
+
+@pytest.mark.parametrize(
+    "file_path,text,expected",
+    [
+        (
+            "workflows/changelog.yml",
+            "uvx towncrier check  --compare-with origin/${{ env.BASE_BRANCH }}",
+            True,
+        ),
+        ("workflows/changelog.yml", "pipx", False),
+        (
+            "workflows/config.yml",
+            "echo 'plone-version: ${{ steps.vars.outputs.plone-version }}",
+            True,
+        ),
+        (
+            "workflows/config.yml",
+            'default: "ghcr.io/collective/volto-addon"',
+            True,
+        ),
+        ("workflows/main.yml", "uses: ./.github/workflows/config.yml", True),
+    ],
+)
+def test_content(cutter_result, file_path: str, text: str, expected: bool):
+    path = (cutter_result.project_path / file_path).resolve()
+    contents = path.read_text()
+    assert (text in contents) is expected

--- a/tests/templates/ci/gh_frontend_addon/test_gh_frontend_addon_cutter.py
+++ b/tests/templates/ci/gh_frontend_addon/test_gh_frontend_addon_cutter.py
@@ -53,3 +53,22 @@ def test_created_files(cutter_result, file_path: str):
     path = (cutter_result.project_path / file_path).resolve()
     assert path.exists()
     assert path.is_file()
+
+
+@pytest.mark.parametrize(
+    "file_path,text,expected",
+    [
+        ("workflows/changelog.yml", "uvx towncrier check --dir packages/", True),
+        ("workflows/changelog.yml", "pipx", False),
+        (
+            "workflows/config.yml",
+            "echo 'node-version: ${{ inputs.node-version }}",
+            True,
+        ),
+        ("workflows/main.yml", "uses: ./.github/workflows/config.yml", True),
+    ],
+)
+def test_content(cutter_result, file_path: str, text: str, expected: bool):
+    path = (cutter_result.project_path / file_path).resolve()
+    contents = path.read_text()
+    assert (text in contents) is expected

--- a/tests/templates/ci/gh_monorepo_addon/test_gh_monorepo_addon_cutter.py
+++ b/tests/templates/ci/gh_monorepo_addon/test_gh_monorepo_addon_cutter.py
@@ -57,3 +57,31 @@ def test_created_files(cutter_result, file_path: str):
     path = (cutter_result.project_path / file_path).resolve()
     assert path.exists()
     assert path.is_file()
+
+
+@pytest.mark.parametrize(
+    "file_path,text,expected",
+    [
+        (
+            "workflows/changelog.yml",
+            "uvx towncrier check  --compare-with origin/${{ env.BASE_BRANCH }}",
+            True,
+        ),
+        ("workflows/changelog.yml", "pipx", False),
+        (
+            "workflows/config.yml",
+            "echo 'plone-version: ${{ steps.vars.outputs.plone-version }}",
+            True,
+        ),
+        (
+            "workflows/config.yml",
+            "image-name-prefix=$(jq -r '.container_images_prefix'",
+            True,
+        ),
+        ("workflows/main.yml", "uses: ./.github/workflows/config.yml", True),
+    ],
+)
+def test_content(cutter_result, file_path: str, text: str, expected: bool):
+    path = (cutter_result.project_path / file_path).resolve()
+    contents = path.read_text()
+    assert (text in contents) is expected

--- a/tests/templates/ci/gh_project/test_gh_project_cutter.py
+++ b/tests/templates/ci/gh_project/test_gh_project_cutter.py
@@ -57,3 +57,31 @@ def test_created_files(cutter_result, file_path: str):
     path = (cutter_result.project_path / file_path).resolve()
     assert path.exists()
     assert path.is_file()
+
+
+@pytest.mark.parametrize(
+    "file_path,text,expected",
+    [
+        (
+            "workflows/changelog.yml",
+            "uvx towncrier check  --compare-with origin/${{ env.BASE_BRANCH }}",
+            True,
+        ),
+        ("workflows/changelog.yml", "pipx", False),
+        (
+            "workflows/config.yml",
+            "echo 'plone-version: ${{ steps.vars.outputs.plone-version }}",
+            True,
+        ),
+        (
+            "workflows/config.yml",
+            "image-name-prefix=$(jq -r '.container_images_prefix'",
+            True,
+        ),
+        ("workflows/main.yml", "uses: ./.github/workflows/config.yml", True),
+    ],
+)
+def test_content(cutter_result, file_path: str, text: str, expected: bool):
+    path = (cutter_result.project_path / file_path).resolve()
+    contents = path.read_text()
+    assert (text in contents) is expected

--- a/tests/templates/projects/classic/test_classic_images.py
+++ b/tests/templates/projects/classic/test_classic_images.py
@@ -4,9 +4,9 @@ import pytest
 @pytest.mark.parametrize(
     "registry,expected_prefix,expected_separator",
     [
-        ("github", "ghcr.io/plonegovbr/plone.org.br-", "-"),
-        ("gitlab", "registry.gitlab.com/plonegovbr/plone.org.br/", "/"),
-        ("docker_hub", "plonegovbr/plone.org.br-", "-"),
+        ("github", "ghcr.io/plonegovbr/plone.org.br", "-"),
+        ("gitlab", "registry.gitlab.com/plonegovbr/plone.org.br", "/"),
+        ("docker_hub", "plonegovbr/plone.org.br", "-"),
     ],
 )
 def test_classic_image_prefix_registry(
@@ -24,7 +24,8 @@ def test_classic_image_prefix_registry(
     # Check backend Makefile (from sub/classic_project_settings)
     backend_makefile = result.project_path / "backend" / "Makefile"
     # Note: In classic template, the IMAGE_NAME_PREFIX is also set in backend/Makefile
-    assert f"IMAGE_NAME_PREFIX={expected_prefix}" in backend_makefile.read_text()
+    assert f"IMAGE_NAME_PREFIX := {expected_prefix}" in backend_makefile.read_text()
     # Ensure no redundant dash
-    assert "$(IMAGE_NAME_PREFIX)backend" in backend_makefile.read_text()
+    assert "$(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend" in backend_makefile.read_text()
+    assert "$(IMAGE_NAME_PREFIX)backend" not in backend_makefile.read_text()
     assert "$(IMAGE_NAME_PREFIX)-backend" not in backend_makefile.read_text()

--- a/tests/templates/projects/monorepo/test_project_images.py
+++ b/tests/templates/projects/monorepo/test_project_images.py
@@ -4,9 +4,9 @@ import pytest
 @pytest.mark.parametrize(
     "registry,expected_prefix,expected_separator",
     [
-        ("github", "ghcr.io/plonegovbr/plone.org.br-", "-"),
-        ("gitlab", "registry.gitlab.com/plonegovbr/plone.org.br/", "/"),
-        ("docker_hub", "plonegovbr/plone.org.br-", "-"),
+        ("github", "ghcr.io/plonegovbr/plone.org.br", "-"),
+        ("gitlab", "registry.gitlab.com/plonegovbr/plone.org.br", "/"),
+        ("docker_hub", "plonegovbr/plone.org.br", "-"),
     ],
 )
 def test_image_prefix_registry(
@@ -34,5 +34,6 @@ def test_image_prefix_registry(
         "jq -r '.container_images_prefix')"
     ) in backend_makefile.read_text()
     # Ensure no redundant dash
-    assert "$(IMAGE_NAME_PREFIX)backend" in backend_makefile.read_text()
+    assert "$(IMAGE_NAME_PREFIX_WITH_SEPARATOR)backend" in backend_makefile.read_text()
+    assert "$(IMAGE_NAME_PREFIX)backend" not in backend_makefile.read_text()
     assert "$(IMAGE_NAME_PREFIX)-backend" not in backend_makefile.read_text()


### PR DESCRIPTION
## What

Removes the `{{ cookiecutter.__container_registry_prefix_separator }}` that was appended to the `__container_image_prefix` computed field, and re-applies the separator only where a container image name is actually assembled.

## Why

Baking the separator into `__container_image_prefix` meant the value flowing into `container_images_prefix` (and into the **plone/meta** GitHub Actions) already carried a trailing `-`. The actions then append their own `-<component>`, producing duplicated dashes in image names — e.g. `ghcr.io/org/project--backend` instead of `ghcr.io/org/project-backend`.

## How

- **Stripped the separator** from `__container_image_prefix` in all schema files:
  - `templates/add-ons/monorepo/cookieplone.json`
  - `templates/projects/classic/cookieplone.json`
  - `templates/projects/monorepo/cookieplone.json`
  - `templates/sub/addon_settings/cookieplone.json`
  - `templates/sub/classic_project_settings/cookieplone.json`
  - `templates/sub/project_settings/cookieplone.json`
- **Re-applied the separator only where images are built** — Makefiles (via a new `IMAGE_NAME_PREFIX_WITH_SEPARATOR`), devops stack files, and the GHA README.
- **Tests**: added `test_content` assertions to every CI cutter test (`gh_backend_addon`, `gh_classic_project`, `gh_frontend_addon`, `gh_monorepo_addon`, `gh_project`), pinning that the workflow image-name-prefix is sourced cleanly from `.container_images_prefix` with no hardcoded separator. Updated the `test_*_images.py` suite accordingly.

## Testing

Full suite green: `make test` → **1353 passed**.

Closes #421