### PR TITLE
Replace remaining pipx usages with uvx across templates

### DIFF
--- a/news/423.internal
+++ b/news/423.internal
@@ -1,0 +1,1 @@
+Replaced the remaining `pipx` usages with `uvx` across templates (release-it hooks, changelog workflows, and docs), so generated projects rely consistently on `uv`. @ericof

--- a/templates/add-ons/aurora_addon/README.md
+++ b/templates/add-ons/aurora_addon/README.md
@@ -11,20 +11,20 @@ Powered by [cookieplone](https://github.com/plone/cookieplone) and [Cookiecutter
 
 ### Prerequisites
 
-- **pipx**: A handy tool for installing and running Python applications.
+- **uv**: An extremely fast Python package and project manager.
 
 ### Installation Guide 🛠️
 
-1. **pipx**
+1. **uv**
 
 ```shell
-pip install pipx
+pip install uv
 ```
 
 ### Generate Your Plone Add-on 🎉
 
 ```shell
-pipx run cookieplone aurora_addon
+uvx cookieplone aurora_addon
 ```
 
 ## Project Generation Options

--- a/templates/add-ons/aurora_addon/{{ cookiecutter.__folder_name }}/.github/workflows/changelog.yml
+++ b/templates/add-ons/aurora_addon/{{ cookiecutter.__folder_name }}/.github/workflows/changelog.yml
@@ -18,8 +18,8 @@ jobs:
           # Fetch all history
           fetch-depth: '0'
 
-      - name: Install pipx
-        run: pip install towncrier
+      - name: Setup uv
+        uses: plone/meta/.github/actions/setup_uv@{{ versions.gha_version_plone_meta }}
 
       - name: Use Node.js
         uses: actions/setup-node@{{ versions.gha_version_setup_node }}
@@ -52,7 +52,7 @@ jobs:
           # compare the current branch with the base branch.
           # Source: https://github.com/actions/checkout/#fetch-all-branches.
           git fetch --no-tags origin ${BASE_BRANCH}
-          towncrier check --dir packages/${ADDON_NAME}
+          uvx towncrier check --dir packages/${ADDON_NAME}
         env:
           BASE_BRANCH: {{ "${{ github.base_ref }}" }}
         if: github.event_name == 'pull_request'

--- a/templates/add-ons/aurora_addon/{{ cookiecutter.__folder_name }}/packages/{{ cookiecutter.frontend_addon_name }}/.release-it.json
+++ b/templates/add-ons/aurora_addon/{{ cookiecutter.__folder_name }}/packages/{{ cookiecutter.frontend_addon_name }}/.release-it.json
@@ -4,8 +4,8 @@
   },
   "hooks": {
     "after:bump": [
-      "pipx run towncrier build --draft --yes --version ${version} > .changelog.draft",
-      "pipx run towncrier build --yes --version ${version}",
+      "uvx towncrier build --draft --yes --version ${version} > .changelog.draft",
+      "uvx towncrier build --yes --version ${version}",
       "cp ../../README.md ./ && cp CHANGELOG.md ../../CHANGELOG.md",
       "python3 -c 'import json; data = json.load(open(\"../../package.json\")); data[\"version\"] = \"${version}\"; json.dump(data, open(\"../../package.json\", \"w\"), indent=2)'",
       "git add ../../CHANGELOG.md ../../package.json"
@@ -16,7 +16,7 @@
     "publish": false
   },
   "git": {
-    "changelog": "pipx run towncrier build --draft --yes --version 0.0.0",
+    "changelog": "uvx towncrier build --draft --yes --version 0.0.0",
     "requireUpstream": false,
     "requireCleanWorkingDir": false,
     "commitMessage": "Release ${version}",

--- a/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/devops/Makefile
+++ b/templates/projects/monorepo/{{ cookiecutter.__folder_name }}/devops/Makefile
@@ -57,7 +57,7 @@ clean: ## remove all build, test, coverage and Python artifacts
 bin/pip:
 	@echo "$(GREEN)==> Python: Setup Virtual Env$(RESET)"
 	python3 -m venv .
-	bin/pip install -U pip pipx
+	bin/pip install -U pip
 
 bin/ansible:
 

--- a/templates/projects/plone7_nick_embedded/README.md
+++ b/templates/projects/plone7_nick_embedded/README.md
@@ -11,20 +11,20 @@ Powered by [cookieplone](https://github.com/plone/cookieplone) and [Cookiecutter
 
 ### Prerequisites
 
-- **pipx**: A handy tool for installing and running Python applications.
+- **uv**: An extremely fast Python package and project manager.
 
 ### Installation Guide 🛠️
 
-1. **pipx**
+1. **uv**
 
 ```shell
-pip install pipx
+pip install uv
 ```
 
 ### Generate Your Plone Add-on 🎉
 
 ```shell
-pipx run cookieplone frontend_addon
+uvx cookieplone frontend_addon
 ```
 
 ## Project Generation Options

--- a/templates/projects/plone7_nick_embedded/{{ cookiecutter.__folder_name }}/.github/workflows/changelog.yml
+++ b/templates/projects/plone7_nick_embedded/{{ cookiecutter.__folder_name }}/.github/workflows/changelog.yml
@@ -18,8 +18,8 @@ jobs:
           # Fetch all history
           fetch-depth: '0'
 
-      - name: Install pipx
-        run: pip install towncrier
+      - name: Setup uv
+        uses: plone/meta/.github/actions/setup_uv@{{ versions.gha_version_plone_meta }}
 
       - name: Use Node.js
         uses: actions/setup-node@{{ versions.gha_version_setup_node }}
@@ -52,7 +52,7 @@ jobs:
           # compare the current branch with the base branch.
           # Source: https://github.com/actions/checkout/#fetch-all-branches.
           git fetch --no-tags origin ${BASE_BRANCH}
-          towncrier check --dir packages/${ADDON_NAME}
+          uvx towncrier check --dir packages/${ADDON_NAME}
         env:
           BASE_BRANCH: {{ "${{ github.base_ref }}" }}
         if: github.event_name == 'pull_request'

--- a/tests/templates/add-ons/aurora_addon/test_aurora_addon_cutter.py
+++ b/tests/templates/add-ons/aurora_addon/test_aurora_addon_cutter.py
@@ -120,3 +120,22 @@ def test_json_schema(
 ):
     path = cutter_result.project_path / file_path
     assert schema_validate_file(path, schema_name)
+
+
+@pytest.mark.parametrize(
+    "file_path,text,expected",
+    [
+        (
+            ".github/workflows/changelog.yml",
+            "uvx towncrier check --dir packages/",
+            True,
+        ),
+        (".github/workflows/changelog.yml", "pipx", False),
+        ("packages/seven-addon/.release-it.json", "uvx towncrier build", True),
+        ("packages/seven-addon/.release-it.json", "pipx", False),
+    ],
+)
+def test_content(cutter_result, file_path: str, text: str, expected: bool):
+    path = (cutter_result.project_path / file_path).resolve()
+    contents = path.read_text()
+    assert (text in contents) is expected

--- a/tests/templates/projects/plone7_nick_embedded/test_cutter.py
+++ b/tests/templates/projects/plone7_nick_embedded/test_cutter.py
@@ -128,3 +128,20 @@ def test_json_schema(
     package_name = cutter_result.context["frontend_addon_name"]
     path = cutter_result.project_path / file_path.format(package_name=package_name)
     assert schema_validate_file(path, schema_name)
+
+
+@pytest.mark.parametrize(
+    "file_path,text,expected",
+    [
+        (
+            ".github/workflows/changelog.yml",
+            "uvx towncrier check --dir packages/",
+            True,
+        ),
+        (".github/workflows/changelog.yml", "pipx", False),
+    ],
+)
+def test_content(cutter_result, file_path: str, text: str, expected: bool):
+    path = (cutter_result.project_path / file_path).resolve()
+    contents = path.read_text()
+    assert (text in contents) is expected


### PR DESCRIPTION
## What

Replaces the remaining `pipx` usages in templates with `uvx`, following up on #404, so generated projects rely consistently on `uv`.

## Why

Several templates still referenced `pipx` to install/run Python tooling. Standardizing on `uvx` keeps generated projects consistent with the rest of the stack.

## Changes

- **release-it** — `templates/add-ons/aurora_addon/.../packages/.../.release-it.json`: 3× `pipx run towncrier build` → `uvx towncrier build`
- **Changelog workflows** — `aurora_addon` and `plone7_nick_embedded` `changelog.yml`: the `Install pipx` step (which actually ran `pip install towncrier`) is replaced by the repo-standard `plone/meta/.github/actions/setup_uv` action, and the check now runs `uvx towncrier check`
- **Docs** — `aurora_addon` and `plone7_nick_embedded` `README.md`: prerequisites/install switched from `pipx` to `uv`; `pipx run cookieplone …` → `uvx cookieplone …`
- **devops Makefile** — `templates/projects/monorepo/.../devops/Makefile`: dropped the never-invoked `pipx` from `bin/pip install -U pip pipx`

## Tests

- Added `test_content` guards to the `aurora_addon` and `plone7_nick_embedded` cutter tests, asserting the baked changelog workflow uses `uvx towncrier` (and aurora's `.release-it.json` uses `uvx towncrier build`) with no `pipx` remaining.
- Full suite green: `make test` → **1359 passed**.

Closes #423