### PR TITLE
VSCode python-envs, storybook-deploy checking, and frontend.yml node-version fixes

### DIFF
--- a/news/428.feature
+++ b/news/428.feature
@@ -1,0 +1,1 @@
+Recommend the `ms-python.vscode-python-envs` VSCode extension and set a default for `python-envs.workspaceSearchPaths` pointing at the backend virtual environment. @ericof

--- a/news/430.feature
+++ b/news/430.feature
@@ -1,0 +1,1 @@
+Compute a `storybook-deploy` flag in the CI `config` workflow (deploy only for public repositories) and pass it through to the storybook job, instead of always deploying. @ericof

--- a/news/431.bugfix
+++ b/news/431.bugfix
@@ -1,0 +1,1 @@
+Fixed the storybook job in the reusable `frontend.yml` workflows to read `node-version` from `inputs` instead of a non-existent `config` job output. @ericof

--- a/templates/ci/gh_frontend_addon/{{ cookiecutter.__folder_name }}/workflows/config.yml
+++ b/templates/ci/gh_frontend_addon/{{ cookiecutter.__folder_name }}/workflows/config.yml
@@ -14,13 +14,17 @@ on:
       node-version:
         description: "Node version to be used"
         value: {{ "${{ inputs.node-version }}" }}
+      storybook-deploy:
+        description: "Whether to deploy storybook or not"
+        value: {{ "${{ jobs.config.outputs.storybook-deploy }}" }}
 
 jobs:
   config:
     runs-on: ubuntu-latest
     outputs:
-      base-tag: {{ "${{ steps.vars.outputs.BASE_TAG }}" }}
-      plone-version: {{ "${{ inputs.node-version }}" }}
+      base-tag: {{ "${{ steps.vars.outputs.base-tag }}" }}
+      node-version: {{ "${{ inputs.node-version }}" }}
+      storybook-deploy: {{ "${{ steps.vars.outputs.storybook-deploy }}" }}
 
     steps:
       - name: Checkout
@@ -29,10 +33,12 @@ jobs:
       - name: Compute several vars needed for the CI
         id: vars
         run: |
-          echo "BASE_TAG=sha-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "base-tag=sha-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "storybook-deploy={{ "${{ github.event.repository.private == false }}" }}" >> $GITHUB_OUTPUT
 
       - name: Test vars
         run: |
-          echo "base-tag: {{ "${{ steps.vars.outputs.BASE_TAG }}" }}"
+          echo "base-tag: {{ "${{ steps.vars.outputs.base-tag }}" }}"
           echo 'node-version: {{ "${{ inputs.node-version }}" }}'
           echo 'event-name: {{ "${{ github.event_name }}" }}'
+          echo 'storybook-deploy: {{ "${{ steps.vars.outputs.storybook-deploy }}" }}'

--- a/templates/ci/gh_frontend_addon/{{ cookiecutter.__folder_name }}/workflows/main.yml
+++ b/templates/ci/gh_frontend_addon/{{ cookiecutter.__folder_name }}/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         - i18n
     with:
         node-version: {{ "${{ needs.config.outputs.node-version }}" }}
-        deploy: true
+        deploy:  {{ "${{ needs.config.outputs.storybook-deploy }}" }}
 
   report:
     name: "Final report"

--- a/templates/ci/gh_monorepo_addon/{{ cookiecutter.__folder_name }}/workflows/config.yml
+++ b/templates/ci/gh_monorepo_addon/{{ cookiecutter.__folder_name }}/workflows/config.yml
@@ -45,6 +45,9 @@ on:
       volto-version:
         description: "Volto version to be used"
         value: {{ "${{ jobs.config.outputs.volto-version }}" }}
+      storybook-deploy:
+        description: "Whether to deploy storybook or not"
+        value: {{ "${{ jobs.config.outputs.storybook-deploy }}" }}
 
 jobs:
   config:
@@ -59,6 +62,7 @@ jobs:
       plone-version: {{ "${{ steps.vars.outputs.plone-version }}" }}
       volto-version: {{ "${{ steps.vars.outputs.volto-version }}" }}
       image-name-prefix: {{ "${{ steps.vars.outputs.image-name-prefix }}" }}
+      storybook-deploy: {{ "${{ steps.vars.outputs.storybook-deploy }}" }}
 
     steps:
       - name: Checkout
@@ -79,6 +83,7 @@ jobs:
           echo "plone-version=$(jq -r '.backend.base_package_version' <<< "$REPOSITORY_SETTINGS")" >> "$GITHUB_OUTPUT"
           echo "volto-version=$(jq -r '.frontend.volto_version' <<< "$REPOSITORY_SETTINGS")" >> "$GITHUB_OUTPUT"
           echo "base-tag=sha-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "storybook-deploy={{ "${{ github.event.repository.private == false }}" }}" >> $GITHUB_OUTPUT
 
       - uses: dorny/paths-filter@{{ versions.gha_version_paths_filter }}
         id: filter
@@ -107,6 +112,7 @@ jobs:
           echo 'image-name-prefix: {{ "${{ steps.vars.outputs.image-name-prefix }}" }}'
           echo 'plone-version: {{ "${{ steps.vars.outputs.plone-version }}" }}'
           echo 'volto-version: {{ "${{ steps.vars.outputs.volto-version }}" }}'
+          echo 'storybook-deploy: {{ "${{ steps.vars.outputs.storybook-deploy }}" }}'
           echo 'event-name: {{ "${{ github.event_name }}" }}'
           echo 'Paths - acceptance: {{ "${{ steps.filter.outputs.acceptance }}" }}'
           echo 'Paths - backend: {{ "${{ steps.filter.outputs.backend }}" }}'

--- a/templates/ci/gh_monorepo_addon/{{ cookiecutter.__folder_name }}/workflows/frontend.yml
+++ b/templates/ci/gh_monorepo_addon/{{ cookiecutter.__folder_name }}/workflows/frontend.yml
@@ -57,7 +57,7 @@ jobs:
       - unit
       - i18n
     with:
-      node-version: {{ "${{ needs.config.outputs.node-version }}" }}
+      node-version: {{ "${{ inputs.node-version }}" }}
       working-directory: {{ "${{ inputs.working-directory }}" }}
       deploy: {{ "${{ inputs.storybook-deploy }}" }}
 

--- a/templates/ci/gh_monorepo_addon/{{ cookiecutter.__folder_name }}/workflows/main.yml
+++ b/templates/ci/gh_monorepo_addon/{{ cookiecutter.__folder_name }}/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
         image-name-suffix: frontend
         node-version: {{ "${{ needs.config.outputs.node-version }}" }}
         volto-version: {{ "${{ needs.config.outputs.volto-version }}" }}
+        storybook-deploy: {{ "${{ needs.config.outputs.storybook-deploy }}" }}
     if: {{ "${{ needs.config.outputs.frontend == 'true' }}" }}
     permissions:
       contents: read

--- a/templates/ci/gh_project/{{ cookiecutter.__folder_name }}/workflows/config.yml
+++ b/templates/ci/gh_project/{{ cookiecutter.__folder_name }}/workflows/config.yml
@@ -48,6 +48,9 @@ on:
       volto-version:
         description: "Volto version to be used"
         value: {{ "${{ jobs.config.outputs.volto-version }}" }}
+      storybook-deploy:
+        description: "Whether to deploy storybook or not"
+        value: {{ "${{ jobs.config.outputs.storybook-deploy }}" }}
 
 jobs:
   config:
@@ -63,6 +66,7 @@ jobs:
       image-name-prefix: {{ "${{ steps.vars.outputs.image-name-prefix }}" }}
       plone-version: {{ "${{ steps.vars.outputs.plone-version }}" }}
       volto-version: {{ "${{ steps.vars.outputs.volto-version }}" }}
+      storybook-deploy: {{ "${{ steps.vars.outputs.storybook-deploy }}" }}
 
     steps:
       - name: Checkout
@@ -84,6 +88,7 @@ jobs:
           echo "plone-version=$(jq -r '.backend.base_package_version' <<< "$REPOSITORY_SETTINGS")" >> "$GITHUB_OUTPUT"
           echo "volto-version=$(jq -r '.frontend.volto_version' <<< "$REPOSITORY_SETTINGS")" >> "$GITHUB_OUTPUT"
           echo "base-tag=sha-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "storybook-deploy={{ "${{ github.event.repository.private == false }}" }}" >> $GITHUB_OUTPUT
 
       - uses: dorny/paths-filter@{{ versions.gha_version_paths_filter }}
         id: filter
@@ -116,6 +121,7 @@ jobs:
           echo 'plone-version: {{ "${{ steps.vars.outputs.plone-version }}" }}'
           echo 'volto-version: {{ "${{ steps.vars.outputs.volto-version }}" }}'
           echo 'event-name: {{ "${{ github.event_name }}" }}'
+          echo 'storybook-deploy: {{ "${{ steps.vars.outputs.storybook-deploy }}" }}'
           echo 'Paths - acceptance: {{ "${{ steps.filter.outputs.acceptance }}" }}'
           echo 'Paths - backend: {{ "${{ steps.filter.outputs.backend }}" }}'
           echo 'Paths - cache: {{ "${{ steps.filter.outputs.cache }}" }}'

--- a/templates/ci/gh_project/{{ cookiecutter.__folder_name }}/workflows/frontend.yml
+++ b/templates/ci/gh_project/{{ cookiecutter.__folder_name }}/workflows/frontend.yml
@@ -57,7 +57,7 @@ jobs:
       - unit
       - i18n
     with:
-      node-version: {{ "${{ needs.config.outputs.node-version }}" }}
+      node-version: {{ "${{ inputs.node-version }}" }}
       working-directory: {{ "${{ inputs.working-directory }}" }}
       deploy: {{ "${{ inputs.storybook-deploy }}" }}
 

--- a/templates/ci/gh_project/{{ cookiecutter.__folder_name }}/workflows/main.yml
+++ b/templates/ci/gh_project/{{ cookiecutter.__folder_name }}/workflows/main.yml
@@ -73,6 +73,7 @@ jobs:
         image-name-suffix: frontend
         node-version: {{ "${{ needs.config.outputs.node-version }}" }}
         volto-version: {{ "${{ needs.config.outputs.volto-version }}" }}
+        storybook-deploy: {{ "${{ needs.config.outputs.storybook-deploy }}" }}
     if: {{ "${{ needs.config.outputs.frontend == 'true' }}" }}
     permissions:
       contents: read

--- a/templates/ide/vscode/cookieplone.json
+++ b/templates/ide/vscode/cookieplone.json
@@ -8,14 +8,14 @@
             "backend_path": {
                 "type": "string",
                 "title": "Backend Path",
-                "description": "Root path of the Python codebase (`/` for the repo root, empty for no Python codebase).",
+                "description": "Root path of the Python codebase (`./` for the repo root, empty for no Python codebase).",
                 "default": "./",
                 "validator": ""
             },
             "frontend_path": {
                 "type": "string",
                 "title": "Frontend Path",
-                "description": "Root path of the Volto codebase (`/` for the repo root, empty for no Volto codebase).",
+                "description": "Root path of the Volto codebase (`./` for the repo root, empty for no Volto codebase).",
                 "default": "./",
                 "validator": ""
             },

--- a/templates/ide/vscode/hooks/post_gen_project.py
+++ b/templates/ide/vscode/hooks/post_gen_project.py
@@ -11,6 +11,7 @@ REPLACEMENTS = (
     (".//", "./"),
     ("../", "./"),
     ("//", "/"),
+    ("backend.venv", "backend/.venv"),
     ("{workspaceFolder}backend", "{workspaceFolder}/backend"),
     ("{workspaceFolder}frontend", "{workspaceFolder}/frontend"),
     (".frontend", "./frontend"),

--- a/templates/ide/vscode/{{ cookiecutter.__folder_name }}/extensions.json
+++ b/templates/ide/vscode/{{ cookiecutter.__folder_name }}/extensions.json
@@ -8,6 +8,7 @@
     {%- if cookiecutter.backend_path != '' %}
     "charliermarsh.ruff",
     "ms-python.python",
+    "ms-python.vscode-python-envs",
     {%- endif %}
     {%- if cookiecutter.ansible_path != '' %}
     "redhat.ansible",

--- a/templates/ide/vscode/{{ cookiecutter.__folder_name }}/settings.json
+++ b/templates/ide/vscode/{{ cookiecutter.__folder_name }}/settings.json
@@ -16,6 +16,9 @@
   {%- endif %}
   {%- if cookiecutter.backend_path != '' %}
   "ruff.organizeImports": true,
+  "python-envs.workspaceSearchPaths": [
+    "{{ cookiecutter.backend_path }}.venv"
+  ],
   "python.terminal.activateEnvironment": true,
   "python.testing.pytestArgs": [
     "{{ cookiecutter.__backend_tests_path }}"

--- a/tests/templates/ci/gh_frontend_addon/test_gh_frontend_addon_cutter.py
+++ b/tests/templates/ci/gh_frontend_addon/test_gh_frontend_addon_cutter.py
@@ -66,6 +66,16 @@ def test_created_files(cutter_result, file_path: str):
             True,
         ),
         ("workflows/main.yml", "uses: ./.github/workflows/config.yml", True),
+        (
+            "workflows/config.yml",
+            "storybook-deploy=${{ github.event.repository.private == false }}",
+            True,
+        ),
+        (
+            "workflows/main.yml",
+            "deploy:  ${{ needs.config.outputs.storybook-deploy }}",
+            True,
+        ),
     ],
 )
 def test_content(cutter_result, file_path: str, text: str, expected: bool):

--- a/tests/templates/ci/gh_monorepo_addon/test_gh_monorepo_addon_cutter.py
+++ b/tests/templates/ci/gh_monorepo_addon/test_gh_monorepo_addon_cutter.py
@@ -89,6 +89,16 @@ def test_created_files(cutter_result, file_path: str):
             "storybook-deploy: ${{ needs.config.outputs.storybook-deploy }}",
             True,
         ),
+        (
+            "workflows/frontend.yml",
+            "node-version: ${{ inputs.node-version }}",
+            True,
+        ),
+        (
+            "workflows/frontend.yml",
+            "needs.config.outputs.node-version",
+            False,
+        ),
     ],
 )
 def test_content(cutter_result, file_path: str, text: str, expected: bool):

--- a/tests/templates/ci/gh_monorepo_addon/test_gh_monorepo_addon_cutter.py
+++ b/tests/templates/ci/gh_monorepo_addon/test_gh_monorepo_addon_cutter.py
@@ -79,6 +79,16 @@ def test_created_files(cutter_result, file_path: str):
             True,
         ),
         ("workflows/main.yml", "uses: ./.github/workflows/config.yml", True),
+        (
+            "workflows/config.yml",
+            "storybook-deploy=${{ github.event.repository.private == false }}",
+            True,
+        ),
+        (
+            "workflows/main.yml",
+            "storybook-deploy: ${{ needs.config.outputs.storybook-deploy }}",
+            True,
+        ),
     ],
 )
 def test_content(cutter_result, file_path: str, text: str, expected: bool):

--- a/tests/templates/ci/gh_project/test_gh_project_cutter.py
+++ b/tests/templates/ci/gh_project/test_gh_project_cutter.py
@@ -89,6 +89,16 @@ def test_created_files(cutter_result, file_path: str):
             "storybook-deploy: ${{ needs.config.outputs.storybook-deploy }}",
             True,
         ),
+        (
+            "workflows/frontend.yml",
+            "node-version: ${{ inputs.node-version }}",
+            True,
+        ),
+        (
+            "workflows/frontend.yml",
+            "needs.config.outputs.node-version",
+            False,
+        ),
     ],
 )
 def test_content(cutter_result, file_path: str, text: str, expected: bool):

--- a/tests/templates/ci/gh_project/test_gh_project_cutter.py
+++ b/tests/templates/ci/gh_project/test_gh_project_cutter.py
@@ -79,6 +79,16 @@ def test_created_files(cutter_result, file_path: str):
             True,
         ),
         ("workflows/main.yml", "uses: ./.github/workflows/config.yml", True),
+        (
+            "workflows/config.yml",
+            "storybook-deploy=${{ github.event.repository.private == false }}",
+            True,
+        ),
+        (
+            "workflows/main.yml",
+            "storybook-deploy: ${{ needs.config.outputs.storybook-deploy }}",
+            True,
+        ),
     ],
 )
 def test_content(cutter_result, file_path: str, text: str, expected: bool):

--- a/tests/templates/ide/vscode/test_ide_vscode_cutter_backend_addon.py
+++ b/tests/templates/ide/vscode/test_ide_vscode_cutter_backend_addon.py
@@ -45,6 +45,22 @@ def test_created_files(cutter_result, load_json, file_path: str, exists: bool):
         assert isinstance(content, dict)
 
 
+EXTENSIONS = [
+    ["extensions.json", f"recommendations/{idx}", extension]
+    for idx, extension in enumerate([
+        "charliermarsh.ruff",
+        "ms-python.python",
+        "ms-python.vscode-python-envs",
+        "ExecutableBookProject.myst-highlight",
+        "ms-vscode-remote.remote-containers",
+        "redhat.vscode-yaml",
+        "editorconfig.editorconfig",
+        "github.vscode-github-actions",
+        "plone.plone-vs-utilities",
+    ])
+]
+
+
 @pytest.mark.parametrize(
     "file_path,path,expected",
     [
@@ -53,16 +69,10 @@ def test_created_files(cutter_result, load_json, file_path: str, exists: bool):
             "configurations/0/program",
             "${workspaceFolder}/.venv/bin/runwsgi",
         ],
-        [
-            "launch.json",
-            "configurations/0/cwd",
-            "${workspaceFolder}/",
-        ],
-        [
-            "settings.json",
-            "python.testing.pytestArgs/0",
-            "./tests",
-        ],
+        ["launch.json", "configurations/0/cwd", "${workspaceFolder}/"],
+        ["settings.json", "python.testing.pytestArgs/0", "./tests"],
+        ["settings.json", "python-envs.workspaceSearchPaths/0", "./.venv"],
+        *EXTENSIONS,
     ],
 )
 def test_settings(

--- a/tests/templates/ide/vscode/test_ide_vscode_cutter_classic_project.py
+++ b/tests/templates/ide/vscode/test_ide_vscode_cutter_classic_project.py
@@ -45,6 +45,23 @@ def test_created_files(cutter_result, load_json, file_path: str, exists: bool):
         assert isinstance(content, dict)
 
 
+EXTENSIONS = [
+    ["extensions.json", f"recommendations/{idx}", extension]
+    for idx, extension in enumerate([
+        "charliermarsh.ruff",
+        "ms-python.python",
+        "ms-python.vscode-python-envs",
+        "redhat.ansible",
+        "ExecutableBookProject.myst-highlight",
+        "ms-vscode-remote.remote-containers",
+        "redhat.vscode-yaml",
+        "editorconfig.editorconfig",
+        "github.vscode-github-actions",
+        "plone.plone-vs-utilities",
+    ])
+]
+
+
 @pytest.mark.parametrize(
     "file_path,path,expected",
     [
@@ -53,16 +70,10 @@ def test_created_files(cutter_result, load_json, file_path: str, exists: bool):
             "configurations/0/program",
             "${workspaceFolder}/backend/.venv/bin/runwsgi",
         ],
-        [
-            "launch.json",
-            "configurations/0/cwd",
-            "${workspaceFolder}/backend",
-        ],
-        [
-            "settings.json",
-            "python.testing.pytestArgs/0",
-            "backend/tests",
-        ],
+        ["launch.json", "configurations/0/cwd", "${workspaceFolder}/backend"],
+        ["settings.json", "python.testing.pytestArgs/0", "backend/tests"],
+        ["settings.json", "python-envs.workspaceSearchPaths/0", "backend/.venv"],
+        *EXTENSIONS,
     ],
 )
 def test_settings(

--- a/tests/templates/ide/vscode/test_ide_vscode_cutter_frontend_addon.py
+++ b/tests/templates/ide/vscode/test_ide_vscode_cutter_frontend_addon.py
@@ -45,14 +45,27 @@ def test_created_files(cutter_result, load_json, file_path: str, exists: bool):
         assert isinstance(content, dict)
 
 
+EXTENSIONS = [
+    ["extensions.json", f"recommendations/{idx}", extension]
+    for idx, extension in enumerate([
+        "dbaeumer.vscode-eslint",
+        "stylelint.vscode-stylelint",
+        "esbenp.prettier-vscode",
+        "ExecutableBookProject.myst-highlight",
+        "ms-vscode-remote.remote-containers",
+        "redhat.vscode-yaml",
+        "editorconfig.editorconfig",
+        "github.vscode-github-actions",
+        "plone.plone-vs-utilities",
+    ])
+]
+
+
 @pytest.mark.parametrize(
     "file_path,path,expected",
     [
-        [
-            "settings.json",
-            "eslint.workingDirectories/0",
-            "./",
-        ],
+        ["settings.json", "eslint.workingDirectories/0", "./"],
+        *EXTENSIONS,
     ],
 )
 def test_settings(

--- a/tests/templates/ide/vscode/test_ide_vscode_cutter_monorepo_addon.py
+++ b/tests/templates/ide/vscode/test_ide_vscode_cutter_monorepo_addon.py
@@ -45,6 +45,25 @@ def test_created_files(cutter_result, load_json, file_path: str, exists: bool):
         assert isinstance(content, dict)
 
 
+EXTENSIONS = [
+    ["extensions.json", f"recommendations/{idx}", extension]
+    for idx, extension in enumerate([
+        "dbaeumer.vscode-eslint",
+        "stylelint.vscode-stylelint",
+        "esbenp.prettier-vscode",
+        "charliermarsh.ruff",
+        "ms-python.python",
+        "ms-python.vscode-python-envs",
+        "ExecutableBookProject.myst-highlight",
+        "ms-vscode-remote.remote-containers",
+        "redhat.vscode-yaml",
+        "editorconfig.editorconfig",
+        "github.vscode-github-actions",
+        "plone.plone-vs-utilities",
+    ])
+]
+
+
 @pytest.mark.parametrize(
     "file_path,path,expected",
     [
@@ -53,21 +72,11 @@ def test_created_files(cutter_result, load_json, file_path: str, exists: bool):
             "configurations/0/program",
             "${workspaceFolder}/backend/.venv/bin/runwsgi",
         ],
-        [
-            "launch.json",
-            "configurations/0/cwd",
-            "${workspaceFolder}/backend",
-        ],
-        [
-            "settings.json",
-            "python.testing.pytestArgs/0",
-            "backend/tests",
-        ],
-        [
-            "settings.json",
-            "eslint.workingDirectories/0",
-            "./frontend",
-        ],
+        ["launch.json", "configurations/0/cwd", "${workspaceFolder}/backend"],
+        ["settings.json", "python.testing.pytestArgs/0", "backend/tests"],
+        ["settings.json", "python-envs.workspaceSearchPaths/0", "backend/.venv"],
+        ["settings.json", "eslint.workingDirectories/0", "./frontend"],
+        *EXTENSIONS,
     ],
 )
 def test_settings(

--- a/tests/templates/ide/vscode/test_ide_vscode_cutter_project .py
+++ b/tests/templates/ide/vscode/test_ide_vscode_cutter_project .py
@@ -40,6 +40,26 @@ def test_created_files(cutter_result, load_json, file_path: str, exists: bool):
         assert isinstance(content, dict)
 
 
+EXTENSIONS = [
+    ["extensions.json", f"recommendations/{idx}", extension]
+    for idx, extension in enumerate([
+        "dbaeumer.vscode-eslint",
+        "stylelint.vscode-stylelint",
+        "esbenp.prettier-vscode",
+        "charliermarsh.ruff",
+        "ms-python.python",
+        "ms-python.vscode-python-envs",
+        "redhat.ansible",
+        "ExecutableBookProject.myst-highlight",
+        "ms-vscode-remote.remote-containers",
+        "redhat.vscode-yaml",
+        "editorconfig.editorconfig",
+        "github.vscode-github-actions",
+        "plone.plone-vs-utilities",
+    ])
+]
+
+
 @pytest.mark.parametrize(
     "file_path,path,expected",
     [
@@ -48,21 +68,10 @@ def test_created_files(cutter_result, load_json, file_path: str, exists: bool):
             "configurations/0/program",
             "${workspaceFolder}/backend/.venv/bin/runwsgi",
         ],
-        [
-            "launch.json",
-            "configurations/0/cwd",
-            "${workspaceFolder}/backend",
-        ],
-        [
-            "settings.json",
-            "python.testing.pytestArgs/0",
-            "backend/tests",
-        ],
-        [
-            "settings.json",
-            "eslint.workingDirectories/0",
-            "./frontend",
-        ],
+        ["launch.json", "configurations/0/cwd", "${workspaceFolder}/backend"],
+        ["settings.json", "python.testing.pytestArgs/0", "backend/tests"],
+        ["settings.json", "eslint.workingDirectories/0", "./frontend"],
+        *EXTENSIONS,
     ],
 )
 def test_settings(

--- a/tests/templates/projects/monorepo/test_project_devops.py
+++ b/tests/templates/projects/monorepo/test_project_devops.py
@@ -94,6 +94,14 @@ def test_project_devops_no_gha_deploy(
     assert path.exists() is False
 
 
+def test_frontend_storybook_node_version(cutter_result):
+    """Storybook job reads node-version from inputs, not a missing config job."""
+    folder = cutter_result.project_path
+    contents = (folder / ".github/workflows/frontend.yml").read_text()
+    assert "node-version: ${{ inputs.node-version }}" in contents
+    assert "needs.config.outputs.node-version" not in contents
+
+
 def test_ansible_inventory_projects_replacement(cutter_result):
     """Test GHA deploy files are not present."""
     folder = cutter_result.project_path


### PR DESCRIPTION
## Summary

Groups three related improvements to the generated VSCode configuration and GitHub Actions CI workflows.

### #428 — VSCode Python environments
- Recommend the `ms-python.vscode-python-envs` extension in the generated `extensions.json` (backend projects).
- Set a default `python-envs.workspaceSearchPaths` in `settings.json` pointing at the backend virtual environment.

### #430 — Storybook deploy checking
- Compute a `storybook-deploy` flag in the CI `config` workflow (`true` only for public repositories) and thread it through `main.yml` to the storybook job, replacing the previous unconditional `deploy: true`.
- Fixed a copy-paste error in `gh_frontend_addon/config.yml` where the `storybook-deploy` job output was wired to `inputs.node-version` instead of the computed value.

### #431 — node-version reference in `frontend.yml`
- The storybook job in the reusable `frontend.yml` read `node-version` from `needs.config.outputs.node-version`, but `frontend.yml` has no `config` job, so the value was always empty. It now uses `inputs.node-version` like the sibling jobs.
- Added regression tests asserting `frontend.yml` never references a `config` job output for `node-version`.

## Tests

Full suite green (1426 passed). New/extended coverage:
- VSCode cutter tests (extension list + `python-envs.workspaceSearchPaths`).
- CI cutter tests (`storybook-deploy` computation and wiring; `frontend.yml` node-version).
- `test_project_devops.py::test_frontend_storybook_node_version`.

Closes #428
Closes #430
Closes #431