### PR TITLE
Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directories:
+      # Workflows under .github/workflows
+      - "/"
+      # Composite actions, which are not covered by the entry above
+      - "/.github/actions/*"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/news/437.internal
+++ b/news/437.internal
@@ -1,0 +1,1 @@
+Added a Dependabot configuration to this repository, so the GitHub Actions used by its own workflows and composite actions are kept up to date. @ericof


### PR DESCRIPTION
# Add a Dependabot configuration to this repository

Closes #437

This repository had no `.github/dependabot.yml`, so the GitHub Actions used by
its own workflows were never updated automatically. #436 gave every generated
codebase a working configuration; this does the same for the template
repository itself.

## What it covers

```yaml
version: 2
updates:

  - package-ecosystem: "github-actions"
    directories:
      - "/"
      - "/.github/actions/*"
    schedule:
      interval: "weekly"
```

The entry uses `directories` rather than the single `directory: "/"` shipped by
the `templates/ci/*` configurations, because `/` only covers
`.github/workflows`. Composite actions are a separate scan location, and this
repository has two of them:

| Action | Third party pin |
| --- | --- |
| `.github/actions/setup_python` | `astral-sh/setup-uv@v8.0.0` |
| `.github/actions/generate` | none, it only calls `setup_python` |

`setup_python` is on the path of every CI run here. It is used directly by
`report.yml`, `test-repository.yml` and `test-template.yml`, and indirectly
through `generate`, which `main.yml` calls three times. With a bare
`directory: "/"` its `setup-uv` pin would never be offered an update.

The glob also means composite actions added later are picked up without
touching this file again.

## Notes

Only the `github-actions` ecosystem is configured, matching the scope of the
templates' own configuration. Python dependencies are out of scope here.
